### PR TITLE
修复ADB连接蓝叠模拟器失败的bug

### DIFF
--- a/src/AutoWSGR/controller/windows_controller.py
+++ b/src/AutoWSGR/controller/windows_controller.py
@@ -66,7 +66,7 @@ class WindowsController:
             for line in lines:
                 if line.startswith("bst.instance.Pie64.status.adb_port="):
                     port = line.split("=")[-1].strip()[1:-1]
-                    dev_name = f"127.0.0.1:{port}"
+                    dev_name = f"ANDROID:///127.0.0.1:{port}"
 
         from logging import ERROR, getLogger
 

--- a/src/AutoWSGR/data/default_settings.yaml
+++ b/src/AutoWSGR/data/default_settings.yaml
@@ -39,7 +39,6 @@ daily_automation:
   auto_expedition: True # 自动重复远征
   auto_gain_bonus: True # 当有任务完成时自动点击
   auto_bath_repair: True # 空闲时自动澡堂修理
-  dock_full_destroy: True # 船坞已满时自动清空，若设置为false则船坞已满后终止所有常规出征任务
   auto_battle: True # 自动打完每日战役次数
   battle_type: "困难潜艇" # 打哪个。可选名称参考"plans/battle/"
 

--- a/src/AutoWSGR/data/plans/normal_fight/8-5AI-only1DD.yaml
+++ b/src/AutoWSGR/data/plans/normal_fight/8-5AI-only1DD.yaml
@@ -14,7 +14,7 @@ repair_mode: [1, 2, 1, 2, 2, 2]
 # NodeLevel
 node_args:
   A:
-    formation: 1
+    formation: 2
     night: False
     enemy_rules:
       - [DD + CL > 1, retreat]


### PR DESCRIPTION
1. 更改8-5默认策略为复纵
2. 删除无用配置
3. 修复ADB无法连接蓝叠模拟器的bug