### PR TITLE
feat: 优化决任务逻辑，使得可维修的船应修尽修

### DIFF
--- a/autowsgr/port/common.py
+++ b/autowsgr/port/common.py
@@ -48,6 +48,7 @@ class WorkShop:
         self.available_time = None
 
     def _time_to_seconds(self, time_str):
+        time_str = time_str.replace('.', ':').replace('：', ':')
         parts = time_str.split(':')
         return int(parts[0]) * 3600 + int(parts[1]) * 60 + int(parts[2])
 


### PR DESCRIPTION
task_runner.py:
· register()中添加quick_repair_mode参数以控制注册时是否快修
· RepairTask()中添加scan()方法用于手动扫描可维修的船; 添加managed_repaired_ships标记位标记runner管理的维修 · DecisiveFight()中引入repair_strategy; 重写repair()以适应盲计时和抛出退出决战的钩子 · 大幅修改DecisiveFightTask()的逻辑以适应中断决战插入维修任务
· TaskRunner()中添加所有任务完成后应修尽修的逻辑
decisive_battle.py:
· 将repair_strategy引入决战逻辑
· 修改need_repair()以抛出钩子
common.py:
· WorkShop的_time_to_seconds()中解决了读取维修时间时将":"识别为"."的问题