### PR TITLE
feat: add POST /api/expedition/check endpoint

### DIFF
--- a/autowsgr/__init__.py
+++ b/autowsgr/__init__.py
@@ -1,3 +1,3 @@
 """AutoWSGR — 战舰少女R 自动化框架 (v2)"""
 
-__version__ = '2.0.3'
+__version__ = '2.0.4.dev1'

--- a/autowsgr/server/main.py
+++ b/autowsgr/server/main.py
@@ -1,11 +1,12 @@
 """FastAPI 主应用 — HTTP REST API 和 WebSocket 端点。
 
 本模块提供以下接口:
-- POST /api/task/start  — 启动任务 (异步执行)
-- POST /api/task/stop   — 停止任务
-- GET  /api/task/status — 查询状态
-- WS   /ws/logs         — 实时日志流
-- WS   /ws/task         — 任务状态更新
+- POST /api/task/start       — 启动任务 (异步执行)
+- POST /api/task/stop        — 停止任务
+- GET  /api/task/status      — 查询状态
+- POST /api/expedition/check — 检查并收取远征
+- WS   /ws/logs              — 实时日志流
+- WS   /ws/task              — 任务状态更新
 
 使用方式:
     uvicorn autowsgr.server.main:app --host 0.0.0.0 --port 8000
@@ -438,6 +439,36 @@ async def task_status():
     """查询当前任务状态。"""
     status = task_manager.get_status()
     return ApiResponse(success=True, data=status)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 远征接口
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@app.post('/api/expedition/check', response_model=ApiResponse)
+async def expedition_check():
+    """检查并收取已完成的远征。"""
+    try:
+        ctx = get_context()
+    except RuntimeError as e:
+        raise HTTPException(status_code=503, detail=str(e)) from e
+
+    if task_manager.is_running:
+        raise HTTPException(status_code=409, detail='任务执行中，无法检查远征')
+
+    from autowsgr.ops.expedition import collect_expedition
+
+    try:
+        result = await asyncio.to_thread(collect_expedition, ctx)
+        return ApiResponse(
+            success=True,
+            data={'collected': result},
+            message='远征检查完成',
+        )
+    except Exception as e:
+        _log.opt(exception=True).warning('[API] 远征检查失败: {}', e)
+        return ApiResponse(success=False, error=str(e))
 
 
 # ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Add a dedicated HTTP endpoint `POST /api/expedition/check` to check and collect completed expeditions.

## Motivation

The GUI frontend needs to trigger expedition collection immediately after connecting to the emulator, preventing expedition pages from blocking subsequent tasks. Previously, expedition checking was only done internally by the backend TaskScheduler during fight intervals, with no way for the frontend to trigger it on demand.

## Changes

- **`autowsgr/server/main.py`**: Add `POST /api/expedition/check` endpoint that calls `collect_expedition(ctx)` via `asyncio.to_thread`. Returns 409 if a task is running, 503 if system not started.
- **`autowsgr/__init__.py`**: Bump version to `2.0.4.dev1` (test release).
- Module docstring updated to list the new endpoint.

## Frontend Integration

The GUI frontend (AutoWSGR-GUI) calls this endpoint:
1. Immediately after system start (before entering idle state)
2. Every 15 minutes via the expedition timer

Both calls are non-blocking with graceful error handling.