### PR TITLE
fix: map page recognition with loot badge & add acquisition API

### DIFF
--- a/autowsgr/__init__.py
+++ b/autowsgr/__init__.py
@@ -1,3 +1,3 @@
 """AutoWSGR — 战舰少女R 自动化框架 (v2)"""
 
-__version__ = '2.0.4.dev1'
+__version__ = '2.0.4'

--- a/autowsgr/server/main.py
+++ b/autowsgr/server/main.py
@@ -5,6 +5,8 @@
 - POST /api/task/stop        — 停止任务
 - GET  /api/task/status      — 查询状态
 - POST /api/expedition/check — 检查并收取远征
+- GET  /api/game/acquisition — OCR 识别今日舰船/战利品获取数量
+- GET  /api/game/context     — 查询游戏运行时计数器
 - WS   /ws/logs              — 实时日志流
 - WS   /ws/task              — 任务状态更新
 
@@ -469,6 +471,67 @@ async def expedition_check():
     except Exception as e:
         _log.opt(exception=True).warning('[API] 远征检查失败: {}', e)
         return ApiResponse(success=False, error=str(e))
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 游戏状态查询接口
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@app.get('/api/game/acquisition', response_model=ApiResponse)
+async def game_acquisition():
+    """从出征面板截图 OCR 识别今日舰船 (X/500) 与战利品 (X/50) 获取数量。
+
+    仅在空闲时可用 (需要控制画面导航到出征面板)。
+    """
+    try:
+        ctx = get_context()
+    except RuntimeError as e:
+        raise HTTPException(status_code=503, detail=str(e)) from e
+
+    if task_manager.is_running:
+        raise HTTPException(status_code=409, detail='任务执行中，无法查询获取数量')
+
+    from autowsgr.ui.map.page import MapPage
+
+    def _recognize() -> dict[str, int | None]:
+        map_page = MapPage(ctx)
+        counts = map_page.get_acquisition_counts()
+        return {
+            'ship_count': counts.ship_count,
+            'ship_max': counts.ship_max,
+            'loot_count': counts.loot_count,
+            'loot_max': counts.loot_max,
+        }
+
+    try:
+        data = await asyncio.to_thread(_recognize)
+        return ApiResponse(success=True, data=data, message='获取数量识别完成')
+    except Exception as e:
+        _log.opt(exception=True).warning('[API] 获取数量识别失败: {}', e)
+        return ApiResponse(success=False, error=str(e))
+
+
+@app.get('/api/game/context', response_model=ApiResponse)
+async def game_context_info():
+    """返回当前游戏上下文中的运行时计数器和状态。
+
+    不需要截图或画面操作，直接读取内存中的计数器。
+    """
+    try:
+        ctx = get_context()
+    except RuntimeError as e:
+        raise HTTPException(status_code=503, detail=str(e)) from e
+
+    return ApiResponse(
+        success=True,
+        data={
+            'dropped_ship_count': ctx.dropped_ship_count,
+            'dropped_loot_count': ctx.dropped_loot_count,
+            'quick_repair_used': ctx.quick_repair_used,
+            'current_page': ctx.current_page,
+        },
+    )
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/autowsgr/ui/tabbed_page.py
+++ b/autowsgr/ui/tabbed_page.py
@@ -287,6 +287,7 @@ def is_tabbed_page(screen: np.ndarray) -> bool:
     """判断截图是否为标签页面 (地图/建造/强化/任务 之一)。
 
     检测逻辑: 5 个标签栏探测点中恰好 1 个蓝色 + 其余全部暗色。
+    允许 1 个探测点被覆盖 (如 "战利品▲" 徽标遮挡激活标签)。
 
     Parameters
     ----------
@@ -301,7 +302,8 @@ def is_tabbed_page(screen: np.ndarray) -> bool:
             blue_count += 1
         elif max(pixel.r, pixel.g, pixel.b) < TAB_DARK_MAX:
             dark_count += 1
-    return blue_count == 1 and dark_count == len(TAB_PROBES) - 1
+    # 允许 1 个探测点为非蓝非暗 (徽标遮挡), 要求至少 4 个可识别
+    return blue_count <= 1 and blue_count + dark_count >= len(TAB_PROBES) - 1
 
 
 def get_active_tab_index(screen: np.ndarray) -> int | None:


### PR DESCRIPTION
## 修改内容

### 1. 修复地图页面识别失败 (战利品 徽标遮挡)

**问题**: 当出征面板出现战利品徽标时，徽标覆盖了 TAB_PROBES[0] 探测点 (0.1415, 0.0417)，导致该点颜色从蓝色变为徽标颜色(红/橙)。is_tabbed_page() 严格要求 1蓝+4暗，因此返回 False，进而 MapPage.is_current_page() 也失败。

**修复**: 放宽 is_tabbed_page() 的检测条件，允许最多1个探测点为非蓝非暗（被徽标遮挡），只要 blue_count + dark_count >= 4 即可。模板匹配层仍然能正确识别页面类型。

### 2. 新增游戏状态查询 API

- GET /api/game/acquisition: 导航至出征面板，通过 OCR 识别今日舰船获取 (X/500) 和战利品获取 (X/50)
- GET /api/game/context: 返回游戏运行时计数器 (dropped_ship_count, dropped_loot_count, quick_repair_used, current_page)

这些接口为前端实现战利品满时结束任务或捞船达到500上限等任务终止条件提供数据支持。

### 3. 版本号更新

2.0.4.dev1 -> 2.0.4

## 修改文件

- autowsgr/ui/tabbed_page.py: 放宽 is_tabbed_page() 检测条件
- autowsgr/server/main.py: 新增 /api/game/acquisition 和 /api/game/context 端点
- autowsgr/__init__.py: 版本号更新为 2.0.4