### PR TITLE
fix(api): navigate to map page before acquisition OCR

### DIFF
--- a/autowsgr/__init__.py
+++ b/autowsgr/__init__.py
@@ -1,3 +1,3 @@
 """AutoWSGR — 战舰少女R 自动化框架 (v2)"""
 
-__version__ = '2.1.4.post1'
+__version__ = '2.1.5'

--- a/autowsgr/server/routes/game.py
+++ b/autowsgr/server/routes/game.py
@@ -38,9 +38,11 @@ async def game_acquisition():
     if task_manager.is_running:
         raise HTTPException(status_code=409, detail='任务执行中，无法查询获取数量')
 
+    from autowsgr.ops.navigate import goto_page
     from autowsgr.ui.map.page import MapPage
 
     def _recognize() -> dict[str, int | None]:
+        goto_page(ctx, '地图页面')
         map_page = MapPage(ctx)
         counts = map_page.get_acquisition_counts()
         return {


### PR DESCRIPTION
## 修改内容/api/game/acquisition 端点之前假设游戏画面已经在地图页面上。添加 `goto_page()` 调用先导航到地图页面，使 API 在任意游戏状态下都可用。同时将版本号更新为 2.1.5。## 变更- `autowsgr/server/routes/game.py`: 在 OCR 识别前调用 `goto_page(ctx, '地图页面')` 导航到出征面板- `autowsgr/__init__.py`: 版本号 2.1.4.post1 → 2.1.5