### PR TITLE
ci: add repository guards to workflow files

### DIFF
--- a/.github/workflows/lunar.yml
+++ b/.github/workflows/lunar.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'OpenWSGR/AutoWSGR'
     runs-on: ubuntu-latest
     steps:
       - uses: 0xWelt/Lunar@main

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   deploy:
+    if: github.repository == 'OpenWSGR/AutoWSGR'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,19 @@
+name: Sync upstream
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'   # 每 6 小时检测上游新提交
+  workflow_dispatch:         # 也可手动触发
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    if: github.repository != 'OpenWSGR/AutoWSGR'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync fork with upstream
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh repo sync ${{ github.repository }} --force


### PR DESCRIPTION
## 问题

Fork 同步 upstream 后会获得 publish workflow，导致 fork 上也尝试发布 PyPI（因缺少 PYPI_API_TOKEN 而失败）。反过来，fork 专用的 sync-upstream workflow 之前被上游删除后也丢失了。

## 方案

用 `if: github.repository == / !=` 条件守卫，让所有 workflow 文件在两个仓库中共存，但只在正确的仓库上执行：

| Workflow | 运行位置 | 守卫条件 |
|---|---|---|
| `python-publish.yml` | 主仓库 | `github.repository == 'OpenWSGR/AutoWSGR'` |
| `lunar.yml` | 主仓库 | `github.repository == 'OpenWSGR/AutoWSGR'` |
| `sync-upstream.yml` | Fork | `github.repository != 'OpenWSGR/AutoWSGR'` |

## 变更

- `python-publish.yml`: 添加 `if` 限制仅在上游执行
- `lunar.yml`: 添加 `if` 限制仅在上游执行
- `sync-upstream.yml`: 重新添加，带有 fork-only 守卫条件，每 6 小时同步一次