### PR TITLE
revert: revert PR #363 (acquisition API navigation + version bump)

### DIFF
--- a/autowsgr/__init__.py
+++ b/autowsgr/__init__.py
@@ -1,3 +1,3 @@
 """AutoWSGR — 战舰少女R 自动化框架 (v2)"""
 
-__version__ = '2.1.5'
+__version__ = '2.1.4.post1'

--- a/autowsgr/server/routes/game.py
+++ b/autowsgr/server/routes/game.py
@@ -38,11 +38,9 @@ async def game_acquisition():
     if task_manager.is_running:
         raise HTTPException(status_code=409, detail='任务执行中，无法查询获取数量')
 
-    from autowsgr.ops.navigate import goto_page
     from autowsgr.ui.map.page import MapPage
 
     def _recognize() -> dict[str, int | None]:
-        goto_page(ctx, '地图页面')
         map_page = MapPage(ctx)
         counts = map_page.get_acquisition_counts()
         return {


### PR DESCRIPTION
撤回 #363 的更改。战役次数应由前端调度器管理，后端只需执行单次。acquisition API 的导航修复将在后续 PR 中以正确方式重新提交。