### PR TITLE
fix(task): prevent campaign double-loop (N×N execution)

### DIFF
--- a/autowsgr/server/routes/task.py
+++ b/autowsgr/server/routes/task.py
@@ -192,7 +192,7 @@ async def _start_campaign(ctx: Any, request: CampaignRequest) -> ApiResponse:
         runner = CampaignRunner(
             ctx,
             campaign_name=request.campaign_name,
-            times=request.times,
+            times=1,
         )
 
         results = []


### PR DESCRIPTION
## 问题

战役路由 \_start_campaign\ 中存在双重循环 bug：
- 外层 \or i in range(request.times)\ 循环 N 次
- \CampaignRunner(times=request.times)\ 内部又循环 N 次
- 导致实际执行 N×N 次战役

## 修复

将 \CampaignRunner(times=1)\ 设为 1，让外层循环控制总次数，每轮只执行一次战役。