### PR TITLE
feat: 添加 POST /api/repair/ship 端点

### DIFF
--- a/autowsgr/server/routes/ops.py
+++ b/autowsgr/server/routes/ops.py
@@ -220,9 +220,7 @@ async def repair_ship(request: RepairShipRequest):
     from autowsgr.ops.repair import repair_ship_by_name
 
     try:
-        repair_secs = await asyncio.to_thread(
-            repair_ship_by_name, ctx, request.ship_name
-        )
+        repair_secs = await asyncio.to_thread(repair_ship_by_name, ctx, request.ship_name)
         if repair_secs < 0:
             return ApiResponse(
                 success=False,


### PR DESCRIPTION
## 概述

添加 `POST /api/repair/ship` 路由端点，支持按舰船名称将指定舰船送入浴室修理。

## 变更

**文件**: `autowsgr/server/routes/ops.py`

- 新增 `RepairShipRequest` 请求模型（`ship_name: str`）
- 新增 `POST /api/repair/ship` 路由，调用已有的 `repair_ship_by_name()` 函数
- 返回修理时间（秒），浴场已满时返回错误

## 请求/响应示例

```
POST /api/repair/ship
{"ship_name": "胡德"}
```

成功响应:
```json
{"success": true, "data": {"ship_name": "胡德", "repair_seconds": 3600}, "message": "胡德 已送入泡澡修理 (3600s)"}
```

浴场已满:
```json
{"success": false, "error": "浴场已满，无法修理 胡德"}
```

## 背景

此端点供 AutoWSGR-GUI 前端的泡澡修理系统使用。GUI 实现了编队预设轮换机制：任务执行前检查编队舰船血量，低于阈值时调用此端点将舰船送入浴室，同时切换到另一套编队预设继续战斗。

底层函数 `repair_ship_by_name()` 已存在于 `autowsgr/ops/repair.py` 中，本 PR 仅添加 HTTP 路由暴露该功能。
