### PR TITLE
Security: Command injection via shell=True in emulator process management

### DIFF
--- a/autowsgr/emulator/os_control/macos.py
+++ b/autowsgr/emulator/os_control/macos.py
@@ -23,7 +23,7 @@ class MacEmulatorManager(EmulatorProcessManager):
         if not self._process_name:
             return False
         try:
-            subprocess.check_output(f'pgrep -f {self._process_name}', shell=True)
+            subprocess.check_output(['pgrep', '-f', self._process_name])
         except subprocess.CalledProcessError:
             return False
 
@@ -39,7 +39,7 @@ class MacEmulatorManager(EmulatorProcessManager):
             raise EmulatorNotFoundError('未设置模拟器路径，无法启动')
 
         try:
-            subprocess.Popen(f'open -a {self._path}', shell=True)
+            subprocess.Popen(['open', '-a', self._path])
             if self._emulator_type == EmulatorType.mumu:
                 self._mumu_restart_instance()
             self.wait_until_online()
@@ -56,7 +56,7 @@ class MacEmulatorManager(EmulatorProcessManager):
         if not self._process_name:
             raise EmulatorError('未设置进程名，无法停止')
         try:
-            subprocess.Popen(f'pkill -9 -f {self._process_name}', shell=True)
+            subprocess.Popen(['pkill', '-9', '-f', self._process_name])
             _log.info('模拟器已停止')
         except Exception as exc:
             raise EmulatorError(f'停止模拟器失败: {exc}') from exc
@@ -74,10 +74,9 @@ class MacEmulatorManager(EmulatorProcessManager):
         if not tool or not os.path.isfile(tool):
             return {}
         proc = subprocess.Popen(
-            f'{tool} info all',
+            [tool, 'info', 'all'],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            shell=True,
         )
         out, _ = proc.communicate()
         try:
@@ -93,9 +92,8 @@ class MacEmulatorManager(EmulatorProcessManager):
         for idx, v in enumerate(info.get('return', {}).get('results', [])):
             if port == v.get('adb_port'):
                 subprocess.Popen(
-                    f'{tool} restart {idx}',
+                    [tool, 'restart', str(idx)],
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
-                    shell=True,
                 )
                 break


### PR DESCRIPTION
## Summary

Security: Command injection via shell=True in emulator process management

## Problem

**Severity**: `High` | **File**: `autowsgr/emulator/os_control/macos.py:L22`

The macOS emulator manager builds shell commands with f-strings and executes them with `shell=True` (e.g., `pgrep -f {self._process_name}`, `open -a {self._path}`, `pkill -9 -f {self._process_name}`, and MuMu tool invocations). If `self._process_name`, `self._path`, or related config-derived values are attacker-controlled (directly or via a malicious config file), this can lead to arbitrary command execution on the host.

## Solution

Avoid `shell=True` and pass argument lists to `subprocess` (`subprocess.run([...], check=True)`). Strictly validate/allowlist executable paths and process names from config. Reject values containing shell metacharacters and resolve paths safely before execution.

## Changes

- `autowsgr/emulator/os_control/macos.py` (modified)