### PR TITLE
feat: 添加决战提示&修复bug

### DIFF
--- a/autowsgr/__init__.py
+++ b/autowsgr/__init__.py
@@ -1,3 +1,3 @@
 """AutoWSGR - 战舰少女R 自动化框架(v2)"""
 
-__version__ = '2.1.9.post9'
+__version__ = '2.1.9.post10'

--- a/autowsgr/ops/decisive/base.py
+++ b/autowsgr/ops/decisive/base.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
 _log = get_logger('ops.decisive')
 
+
 class DecisiveBase:
     """决战控制器基类。
 
@@ -66,9 +67,9 @@ class DecisiveBase:
         }
         merged_config = DecisiveConfig(**merged_config_dict)
         self._config = merged_config
-        _log.info('[决战] 当前运行配置: {}',merged_config)
-        if(len(merged_config.level1)<6):
-          _log.warning('[决战] 一级舰队小于6艘, 请检查配置是否有误')
+        _log.info('[决战] 当前运行配置: {}', merged_config)
+        if len(merged_config.level1) < 6:
+            _log.warning('[决战] 一级舰队小于6艘, 请检查配置是否有误')
 
         # 将决战配置中的舰船名 + 技能名合并到全局 SHIPNAMES，
         # 后续 OCR 识别无需再临时拼接候选列表。

--- a/autowsgr/ops/decisive/base.py
+++ b/autowsgr/ops/decisive/base.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from autowsgr.constants import DECISIVE_SKILL_NAMES, update_shipnames
-from autowsgr.infra import DecisiveConfig
+from autowsgr.infra import DecisiveConfig, get_logger
 from autowsgr.ops.decisive.logic import DecisiveLogic
 from autowsgr.ops.decisive.state import DecisiveState
 from autowsgr.ui.decisive import DecisiveBattlePage, DecisiveMapController
@@ -19,6 +19,7 @@ from autowsgr.ui.decisive import DecisiveBattlePage, DecisiveMapController
 if TYPE_CHECKING:
     from autowsgr.context import GameContext
 
+_log = get_logger('ops.decisive')
 
 class DecisiveBase:
     """决战控制器基类。
@@ -65,6 +66,9 @@ class DecisiveBase:
         }
         merged_config = DecisiveConfig(**merged_config_dict)
         self._config = merged_config
+        _log.info('[决战] 当前运行配置: {}',merged_config)
+        if(len(merged_config.level1)<6):
+          _log.warning('[决战] 一级舰队小于6艘, 请检查配置是否有误')
 
         # 将决战配置中的舰船名 + 技能名合并到全局 SHIPNAMES，
         # 后续 OCR 识别无需再临时拼接候选列表。

--- a/autowsgr/ops/decisive/handlers.py
+++ b/autowsgr/ops/decisive/handlers.py
@@ -245,6 +245,7 @@ class DecisivePhaseHandlers(DecisiveBase):
                 if name not in {'长跑训练', '肌肉记忆', '黑科技'}:
                     self._state.ships.add(name)
 
+        self._state.phase = DecisivePhase.PREPARE_COMBAT
         if not self._map.close_fleet_overlay():
             _log.info('[决战] 关闭决战选船界面失败, 选择第一艘后撤退')
             self._state.phase = DecisivePhase.RETREAT
@@ -252,7 +253,6 @@ class DecisivePhaseHandlers(DecisiveBase):
             self._map.buy_fleet_option(first_value.click_position)
             if not self._map.close_fleet_overlay():
                 raise RuntimeError('关闭决战选船界面失败')
-        self._state.phase = DecisivePhase.PREPARE_COMBAT
 
     def _handle_advance_choice(self) -> None:
         """选择前进点。"""

--- a/autowsgr/ui/battle/fleet_change/_change.py
+++ b/autowsgr/ui/battle/fleet_change/_change.py
@@ -633,6 +633,8 @@ class FleetChangeMixin(FleetDetectMixin):
             self._ctrl,
             ChooseShipPage.is_current_page,
             timeout=_CHOOSE_PAGE_TIMEOUT,
+            source='编队',
+            target='编队选船',
         )
         choose_page = ChooseShipPage(self._ctx)
         return choose_page.change_single_ship(

--- a/autowsgr/ui/choose_ship_page.py
+++ b/autowsgr/ui/choose_ship_page.py
@@ -144,7 +144,7 @@ class ChooseShipPage:
         return result.matched
 
     def _wait_leave_current_page(self, timeout: float = 5.0):
-        wait_leave_page(self._ctrl, self.is_current_page, timeout=timeout)
+        wait_leave_page(self._ctrl, self.is_current_page, timeout=timeout, source='编队选船',target='编队')
 
     # ── 操作 ──────────────────────────────────────────────────────────────
     def ensure_search_box(self) -> None:

--- a/autowsgr/ui/choose_ship_page.py
+++ b/autowsgr/ui/choose_ship_page.py
@@ -144,7 +144,9 @@ class ChooseShipPage:
         return result.matched
 
     def _wait_leave_current_page(self, timeout: float = 5.0):
-        wait_leave_page(self._ctrl, self.is_current_page, timeout=timeout, source='编队选船',target='编队')
+        wait_leave_page(
+            self._ctrl, self.is_current_page, timeout=timeout, source='编队选船', target='编队'
+        )
 
     # ── 操作 ──────────────────────────────────────────────────────────────
     def ensure_search_box(self) -> None:

--- a/autowsgr/ui/decisive/battle_page.py
+++ b/autowsgr/ui/decisive/battle_page.py
@@ -52,8 +52,6 @@ PAGE_SIGNATURE = PixelSignature(
         PixelRule.of(0.9695, 0.8500, (15, 31, 56), tolerance=30.0),
         PixelRule.of(0.7641, 0.8611, (22, 46, 84), tolerance=30.0),
         PixelRule.of(0.0453, 0.0667, (38, 39, 43), tolerance=30.0),
-        # 底部“重置关卡”按钮文字（白色）—— 与战役/出征地图区分的关键点
-        PixelRule.of(0.500, 0.925, (255, 255, 255), tolerance=30.0),
     ],
 )
 """决战页面像素签名。"""

--- a/autowsgr/ui/decisive/fleet_ocr.py
+++ b/autowsgr/ui/decisive/fleet_ocr.py
@@ -134,6 +134,8 @@ def recognize_fleet_options(
             continue
         costs.append(cost)
     _log.debug('[舰队OCR] 识别到 {} 项费用: {}', len(costs), costs)
+    if any(c < 4 for c in costs):
+        _log.warning('[舰队OCR] 识别到小于4的费用, 建议检查配队是否有误')
 
     # 3. 恢复原版行为：仅对可购买项识别舰名
     selections: dict[str, FleetSelection] = {}

--- a/autowsgr/ui/decisive/map_controller.py
+++ b/autowsgr/ui/decisive/map_controller.py
@@ -560,6 +560,8 @@ class DecisiveMapController:
             CLICK_FORMATION,
             BattlePreparationPage.is_current_page,
             config=config,
+            source='决战地图',
+            target='出征准备',
         )
 
     def click_sortie(self) -> None:

--- a/autowsgr/ui/decisive/overlay.py
+++ b/autowsgr/ui/decisive/overlay.py
@@ -132,7 +132,7 @@ CLICK_RETREAT_BUTTON: tuple[float, float] = (36 / 960, 33 / 540)
 CLICK_SORTIE: tuple[float, float] = (900 / 960, 500 / 540)
 """右下角「出征」按钮 — 进入出征准备页。"""
 
-CLICK_FLEET_EDIT: tuple[float, float] = (700 / 960, 500 / 540)
+CLICK_FORMATION: tuple[float, float] = (700 / 960, 500 / 540)
 """右下角「编队」按钮 — 进入编队页面。"""
 
 CLICK_BUY_EXP: tuple[float, float] = (75 / 960, 500 / 540)
@@ -141,7 +141,6 @@ CLICK_BUY_EXP: tuple[float, float] = (75 / 960, 500 / 540)
 CLICK_SKILL: tuple[float, float] = (0.2143, 0.894)
 """副官技能按钮。"""
 
-CLICK_FORMATION: tuple[float, float] = (0.75, 0.925)
 
 # ── 战备舰队获取 overlay ──
 


### PR DESCRIPTION
1. 推送到pip
2. 输出决战运行配置
3. 修复初始选不到船卡死的问题
4. 添加导航提示
5. 修复决战在"已重置"状态下无法识别的问题（回撤 #451 的修改）
6. 添加决战费用小于4的警告
7. 删除未使用的CLICK_FLEET_EDIT