### PR TITLE
feat(decisive): 增加换船算法切换开关

### DIFF
--- a/autowsgr/infra/config.py
+++ b/autowsgr/infra/config.py
@@ -292,6 +292,8 @@ class DecisiveConfig(BaseModel):
     """决战章节 (1-6)"""
     decisive_rounds: int = 1
     """决战连续执行轮数"""
+    use_new_fleet_change_algorithm: bool = False
+    """决战是否使用新的换船算法；关闭时继续使用原有流程。"""
     level1: list[str] = Field(
         default_factory=lambda: ['鲃鱼', 'U-1206', 'U-47', '射水鱼', 'U-96', 'U-1405']
     )

--- a/autowsgr/server/routes/task.py
+++ b/autowsgr/server/routes/task.py
@@ -293,6 +293,7 @@ async def _start_decisive(ctx: Any, request: DecisiveRequest) -> ApiResponse:
         config = DecisiveConfig(
             chapter=request.chapter,
             decisive_rounds=request.decisive_rounds,
+            use_new_fleet_change_algorithm=request.use_new_fleet_change_algorithm,
             level1=request.level1,
             level2=request.level2,
             flagship_priority=request.flagship_priority,

--- a/autowsgr/server/schemas.py
+++ b/autowsgr/server/schemas.py
@@ -232,6 +232,10 @@ class DecisiveRequest(BaseModel):
     type: Literal[TaskType.DECISIVE] = TaskType.DECISIVE
     chapter: int = Field(default=6, ge=1, le=6, description='决战章节')
     decisive_rounds: int = Field(default=1, ge=1, description='决战执行轮数')
+    use_new_fleet_change_algorithm: bool = Field(
+        default=False,
+        description='决战是否使用新的换船算法；关闭时使用原有流程',
+    )
     level1: list[str] = Field(
         default_factory=lambda: [
             'U-1206',

--- a/autowsgr/ui/decisive/legacy_fleet_change.py
+++ b/autowsgr/ui/decisive/legacy_fleet_change.py
@@ -1,0 +1,95 @@
+"""决战原有换船流程。
+
+保留不带目标舰名上下文的 OCR 路径，供新换船算法关闭时使用。
+共享 OCR 模块中的全局置信度配置仍然生效。
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from autowsgr.infra.logger import get_logger
+
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from autowsgr.ui.decisive.preparation import DecisiveBattlePreparationPage
+
+
+_log = get_logger('ui.decisive.preparation')
+_MAX_SET_RETRIES = 2
+
+
+def change_fleet_legacy(
+    page: DecisiveBattlePreparationPage,
+    fleet_id: int | None,
+    ship_names: Sequence[str | None],
+) -> bool:
+    """使用原有的完整对齐流程更换决战舰队。"""
+    if fleet_id == 1:
+        raise ValueError('不支持更换 1 队舰船编成')
+
+    if fleet_id and page.get_selected_fleet(page._ctrl.screenshot()) != fleet_id:
+        page.select_fleet(fleet_id)
+        time.sleep(0.5)
+
+    names = [
+        name.strip() if isinstance(name, str) and name.strip() else None
+        for name in list(ship_names)[:6]
+    ]
+    names += [None] * (6 - len(names))
+    selectors: list[dict | None] = [None] * 6
+    _log.info('[决战] 使用原有换船流程，目标编成: {}', names)
+
+    for attempt in range(_MAX_SET_RETRIES + 1):
+        # 不传 expected_names，保持原有的全船池 OCR 匹配方式。
+        current = page.detect_fleet()
+        if page._validate_with_selector(current, names, selectors):
+            return True
+
+        ok, matched_slots = page._match_existing_members(current, names, selectors)
+        for target_slot, name in enumerate(names):
+            if name is None or target_slot in matched_slots:
+                continue
+
+            slot = next((index for index in range(6) if not ok[index]), None)
+            if slot is None:
+                _log.warning("[决战] 无可用槽位放置 '{}'", name)
+                continue
+
+            selected = page._change_single_ship(
+                slot,
+                name,
+                selector=None,
+                slot_occupied=current[slot] is not None,
+            )
+            current[slot] = selected if selected is not None else name
+            ok[slot] = True
+            matched_slots.add(target_slot)
+            time.sleep(0.3)
+
+        for slot in range(5, -1, -1):
+            if not ok[slot] and current[slot] is not None:
+                page._change_single_ship(slot, None, slot_occupied=True)
+                current[slot] = None
+                time.sleep(0.3)
+
+        current = page.detect_fleet()
+        page._reorder(current, names)
+        current = page.detect_fleet()
+        if page._validate_with_selector(current, names, selectors):
+            _log.info('[决战] 原有换船流程完成: {}', current)
+            return True
+
+        if attempt < _MAX_SET_RETRIES:
+            _log.warning(
+                '[决战] 原有换船流程第 {}/{} 次验证失败，重试',
+                attempt + 1,
+                _MAX_SET_RETRIES + 1,
+            )
+            time.sleep(0.5)
+
+    _log.error('[决战] 原有换船流程在重试后仍然失败')
+    return False

--- a/autowsgr/ui/decisive/preparation.py
+++ b/autowsgr/ui/decisive/preparation.py
@@ -20,9 +20,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from autowsgr.ui.battle.preparation import BattlePreparationPage
+from autowsgr.ui.decisive.legacy_fleet_change import change_fleet_legacy
 
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from autowsgr.context import GameContext
     from autowsgr.infra import DecisiveConfig
     from autowsgr.vision import OCREngine
@@ -56,3 +59,13 @@ class DecisiveBattlePreparationPage(BattlePreparationPage):
         super().__init__(ctx, ocr)
         self._ocr: OCREngine = ocr or ctx.ocr  # type: ignore[assignment]
         self._config = config
+
+    def change_fleet(
+        self,
+        fleet_id: int | None,
+        ship_names: Sequence[str | None],
+    ) -> bool:
+        """按配置选择决战原有流程或新的换船算法。"""
+        if self._config.use_new_fleet_change_algorithm:
+            return super().change_fleet(fleet_id, ship_names)
+        return change_fleet_legacy(self, fleet_id, ship_names)

--- a/testing/infra/test_config.py
+++ b/testing/infra/test_config.py
@@ -57,6 +57,14 @@ class TestDecisiveConfig:
         with pytest.raises(ValueError, match='决战章节'):
             DecisiveConfig(chapter=0)
 
+    def test_fleet_change_algorithm_is_disabled_by_default(self):
+        assert DecisiveConfig().use_new_fleet_change_algorithm is False
+
+    def test_fleet_change_algorithm_can_be_enabled(self):
+        config = DecisiveConfig(use_new_fleet_change_algorithm=True)
+
+        assert config.use_new_fleet_change_algorithm is True
+
 
 # ── UserConfig ──
 

--- a/testing/ui/battle_preparation/test_unit.py
+++ b/testing/ui/battle_preparation/test_unit.py
@@ -10,6 +10,7 @@ import pytest
 
 from autowsgr.context import GameContext
 from autowsgr.emulator import AndroidController
+from autowsgr.infra import DecisiveConfig
 from autowsgr.ui.battle.base import PAGE_SIGNATURE
 from autowsgr.ui.battle.constants import (
     AUTO_SUPPLY_PROBE,
@@ -26,6 +27,8 @@ from autowsgr.ui.battle.preparation import (
     BattlePreparationPage,
     Panel,
 )
+from autowsgr.ui.decisive.legacy_fleet_change import change_fleet_legacy
+from autowsgr.ui.decisive.preparation import DecisiveBattlePreparationPage
 
 
 if TYPE_CHECKING:
@@ -289,3 +292,70 @@ class TestToggles:
         pg, ctrl = page
         pg.toggle_auto_supply()
         ctrl.click.assert_called_once_with(*CLICK_AUTO_SUPPLY)
+
+
+# ─────────────────────────────────────────────
+# 决战换船算法开关
+# ─────────────────────────────────────────────
+
+
+class TestDecisiveFleetChangeFeatureGate:
+    def test_original_flow_uses_pool_ocr_without_target_context(self):
+        page = MagicMock()
+        page.detect_fleet.return_value = ['A', None, None, None, None, None]
+        page._validate_with_selector.return_value = True
+
+        assert change_fleet_legacy(page, None, ['A'])
+
+        page.detect_fleet.assert_called_once_with()
+
+    def test_original_flow_changes_ship_and_verifies_result(self):
+        page = MagicMock()
+        empty_fleet = [None] * 6
+        target_fleet = ['A', None, None, None, None, None]
+        page.get_selected_fleet.return_value = 3
+        page.detect_fleet.side_effect = [empty_fleet, target_fleet, target_fleet]
+        page._validate_with_selector.side_effect = [False, True]
+        page._match_existing_members.return_value = ([False] * 6, set())
+        page._change_single_ship.return_value = 'A'
+
+        with patch('autowsgr.ui.decisive.legacy_fleet_change.time.sleep'):
+            assert change_fleet_legacy(page, 2, [' A '])
+
+        page.select_fleet.assert_called_once_with(2)
+        page._change_single_ship.assert_called_once_with(
+            0,
+            'A',
+            selector=None,
+            slot_occupied=False,
+        )
+        page._reorder.assert_called_once_with(target_fleet, target_fleet)
+
+    def test_decisive_uses_original_flow_by_default(self):
+        page = DecisiveBattlePreparationPage(
+            _make_ctx(MagicMock(spec=AndroidController)),
+            DecisiveConfig(),
+        )
+
+        with patch(
+            'autowsgr.ui.decisive.preparation.change_fleet_legacy',
+            return_value=True,
+        ) as legacy_change:
+            assert page.change_fleet(None, ['A'])
+
+        legacy_change.assert_called_once_with(page, None, ['A'])
+
+    def test_decisive_uses_new_flow_when_enabled(self):
+        page = DecisiveBattlePreparationPage(
+            _make_ctx(MagicMock(spec=AndroidController)),
+            DecisiveConfig(use_new_fleet_change_algorithm=True),
+        )
+
+        with patch.object(
+            BattlePreparationPage,
+            'change_fleet',
+            return_value=True,
+        ) as new_change:
+            assert page.change_fleet(None, ['A'])
+
+        new_change.assert_called_once_with(None, ['A'])


### PR DESCRIPTION
## 改动

- 为 `DecisiveConfig` 和决战 API 增加 `use_new_fleet_change_algorithm` 开关。
- 默认关闭时保留原有决战换船及全船池 OCR 流程。
- 开启后使用准备页共享的新版换船算法。
- 将原有决战换船流程独立保存，避免后续智能换船改动改变默认行为。

## 过渡说明

该开关是暂时性的兼容方案，用于智能换船上线期间保留原有决战流程。待后续决战流程优化完成并验证稳定后，将移除该开关和旧流程分支，决战统一使用优化后的流程。

## 兼容性

- 开关默认值为 `false`，现有配置无需修改。
- API 未传该字段时仍使用原有决战流程。

## 验证

- `uv run pytest testing/infra/test_config.py testing/ui/battle_preparation/test_unit.py -q`：82 passed
- Ruff check：通过
- Ruff format check：通过