### PR TITLE
feat(fleet): 实现舰队智能换船与失败中止

### DIFF
--- a/autowsgr/ops/normal_fight.py
+++ b/autowsgr/ops/normal_fight.py
@@ -30,6 +30,12 @@ if TYPE_CHECKING:
 _log = get_logger('ops')
 
 
+def _require_fleet_change(success: bool, source: str) -> None:
+    """换船失败时停止出征，避免使用错误舰队进入战斗。"""
+    if not success:
+        raise ActionFailedError(f'{source} 编队失败')
+
+
 class NormalFightRunner:
     """常规战斗执行器。"""
 
@@ -368,16 +374,16 @@ class NormalFightRunner:
 
         # 换船 (若提供了规则则优先按规则执行)
         if self._fleet_rules is not None:
-            page.change_fleet(
-                self._fleet_id,
-                self._fleet_rules,
+            _require_fleet_change(
+                page.change_fleet(self._fleet_id, self._fleet_rules),
+                '外部 fleet_rules',
             )
             time.sleep(0.5)
             resolved_ship_names = page.detect_fleet()
         elif self._fleet is not None:
-            page.change_fleet(
-                self._fleet_id,
-                self._fleet,
+            _require_fleet_change(
+                page.change_fleet(self._fleet_id, self._fleet),
+                'fleet',
             )
             time.sleep(0.5)
 

--- a/autowsgr/ui/battle/fleet_change/_change.py
+++ b/autowsgr/ui/battle/fleet_change/_change.py
@@ -1,20 +1,23 @@
-"""舰队编成更换 -- 更换算法。
+"""智能换船算法。
 
-实现 "扫描 -> 定点更换 -> 调整次序" 的统一换船流程,
-对齐 legacy ``Fleet._set_ships`` / ``Fleet.reorder`` 算法。
-
-常规出征与决战共用此 Mixin, 通过实例属性 ``_use_search``
-控制选船页面是否使用搜索框:
-
-- ``True`` (默认): 常规出征, 使用搜索框输入舰船名
-- ``False``: 决战模式, 直接 OCR 列表点击
+1. 读取 YAML 传入的前六个舰队槽位。
+2. 整理每个槽位的优选、备选和筛选条件。
+3. 使用回溯算法为六个槽位分配不同舰名。
+4. OCR 识别当前舰队，已经正确时直接结束。
+5. 首次调整时保留可复用舰船并补齐缺少舰船。
+6. 先替换目标舰船，再删除多余舰船，避免一队为空。
+7. 删除舰船造成槽位压缩后，再检查并补齐缺员。
+8. 拖拽舰船，将现有成员调整到目标槽位。
+9. OCR 再次验证舰名、顺序和空槽。
+10. 验证失败后只修正错误槽位，最多修正两次。
+一个 YAML 只执行一套舰队，不会切换其他 preset。
+常规出征使用搜索框，决战可通过开关选择是否使用本算法。
 """
 
 from __future__ import annotations
 
 import re
 import time
-from collections import Counter
 from typing import TYPE_CHECKING, TypedDict
 
 from autowsgr.infra.logger import get_logger
@@ -23,13 +26,15 @@ from autowsgr.ui.battle.constants import CLICK_SHIP_SLOT
 from ._detect import FleetDetectMixin
 
 
+# 仅在类型检查时导入 Sequence，运行时不产生额外依赖。
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
 
+# 记录智能换船过程中的关键步骤和失败原因。
 _log = get_logger('ui.preparation')
 
-# change_fleet 最大重试次数 (对齐 legacy Fleet.set_ship 的 max_retries=2)
+# 首次完整对齐失败后，最多执行两次局部修正
 _MAX_SET_RETRIES: int = 2
 
 # 等待选船页面出现的超时 (秒)
@@ -39,9 +44,11 @@ _CHOOSE_PAGE_TIMEOUT: float = 5.0
 _SHIP_ALIAS_SUFFIX_RE = re.compile(r'\s*[（(][^（）()]*[)）]\s*$')
 
 
+# 描述一个槽位可以使用的舰名和筛选条件。
 class FleetSlotSelector(TypedDict, total=False):
     """编队槽位规则。"""
 
+    name: str
     candidates: list[str]
     search_name: str
     ship_type: str
@@ -49,80 +56,43 @@ class FleetSlotSelector(TypedDict, total=False):
     max_level: int
 
 
+# 一个槽位可以是固定舰名、带条件的规则或空槽。
 FleetSlotInput = str | FleetSlotSelector | None
 
 
+# 为普通出征和决战准备页提供同一套智能换船流程。
 class FleetChangeMixin(FleetDetectMixin):
-    """舰队编成更换 Mixin。
+    """准备页换船逻辑。"""
 
-    实例属性 ``_use_search`` 控制选船页面是否使用搜索框:
-
-    - ``True`` (默认): 常规出征, 使用搜索框输入舰船名
-    - ``False``: 决战模式, 直接 OCR 列表点击
-
-    依赖 :class:`~autowsgr.ui.battle.base.BaseBattlePreparation` 提供的
-    ``_ctx``, ``_ctrl``, ``_ocr``, ``click_ship_slot``,
-    ``get_selected_fleet``, ``select_fleet``,
-    以及 :class:`._detect.FleetDetectMixin` 提供的
-    ``detect_fleet``, ``_validate_fleet``。
-    """
-
+    # True 使用搜索框选船，False 直接通过 OCR 列表选船。
     _use_search: bool = True
 
-    # ══════════════════════════════════════════════════════════════════════
-    # 主入口
-    # ══════════════════════════════════════════════════════════════════════
-
-    def change_fleet(  # noqa: C901, PLR0912, PLR0915
+    # 执行一套六槽舰队的完整换船、排序和验证流程。
+    def change_fleet(  # noqa: PLR0912
         self,
         fleet_id: int | None,
         ship_names: Sequence[FleetSlotInput],
     ) -> bool:
-        """更换编队全部舰船 -- 扫描 -> 定点更换 -> 调整次序。
-
-        **三步算法** (对齐 legacy ``Fleet._set_ships`` + ``Fleet.reorder``):
-
-        1. **扫描**: OCR 识别当前舰队, 前置短路判断是否已满足目标。
-        2. **成员对齐** (``_set_ships``): 标记 ok/not-ok, 定点替换缺失舰船,
-           从后往前移除多余舰船。
-        3. **位置对齐** (``_reorder``): 通过滑动拖拽将每艘船移到正确槽位。
-
-        失败时自动重试 (最多 ``_MAX_SET_RETRIES`` 次)。
-
-        Parameters
-        ----------
-        fleet_id:
-            舰队编号 (2-4); ``None`` 代表不指定舰队。1 队不支持更换。
-        ship_names:
-            目标槽位列表 (按槽位 0-5 顺序); 每个元素可为:
-
-            - ``str``: 目标舰船名
-            - ``dict``: 规则对象 (``candidates`` / ``search_name`` /
-              ``ship_type`` / ``min_level`` / ``max_level``)
-            - ``None``: 留空
-
-            另外也兼容具备同名属性的 selector-like 对象。
-
-        Returns
-        -------
-        bool
-            ``True`` 表示最终验证通过, ``False`` 表示全部重试失败。
-        """
-        if fleet_id == 1:
-            raise ValueError('不支持更换 1 队舰船编成')
-
+        """返回最终舰队是否符合六个目标槽位。"""
+        # Step 1：切换到 YAML 指定的舰队。
+        # 当前舰队已经正确时，不重复点击舰队按钮。
         if fleet_id and self.get_selected_fleet(self._ctrl.screenshot()) != fleet_id:
             self.select_fleet(fleet_id)
             time.sleep(0.5)
 
+        # Step 2：分别保存六个槽位的目标舰名和选船规则。
         names: list[str | None] = []
         selectors: list[dict | None] = []
         for raw_slot in list(ship_names)[:6]:
             selector = self._extract_selector(raw_slot)
             selectors.append(selector)
+
+            # 字符串槽位直接使用该舰名。
             if isinstance(raw_slot, str):
                 names.append(self._normalize_ship_name(raw_slot))
+            # 规则槽位先把第一个候选作为优选舰名。
             elif selector is not None:
+                # candidates 按 YAML 中的填写顺序保存优选和备选。
                 candidates = selector.get('candidates', [])
                 if isinstance(candidates, list) and len(candidates) > 0:
                     names.append(self._normalize_ship_name(candidates[0]))
@@ -131,143 +101,52 @@ class FleetChangeMixin(FleetDetectMixin):
             else:
                 names.append(None)
 
+        # Step 3：不足六槽时补空，并为所有槽位分配互不重复的舰名。
         names += [None] * (6 - len(names))
         selectors += [None] * (6 - len(selectors))
+        # unique_names 是处理候选冲突后的最终目标舰名。
+        unique_names = self._assign_unique_targets(names, selectors)
+        # 无法找到不重名组合时，停止换船，避免组成非法舰队。
+        if unique_names is None:
+            _log.error('[准备页] 目标编成无法满足同名舰唯一约束: {}', names)
+            return False
+        names = unique_names
+        # 一队最后一艘船不能移除，因此槽位 0 必须有目标舰船。
+        if fleet_id == 1 and names[0] is None:
+            raise ValueError('1 队槽位 0 不能为空')
         _log.info('[准备页] 目标编成: {}', names)
 
+        # Step 4：首次完整调整，后续最多进行两次局部修正。
         for attempt in range(_MAX_SET_RETRIES + 1):
-            # ── 1. 扫描当前舰队 ──────────────────────────────────────
+            # current 保存本轮开始时 OCR 识别到的六个槽位。
             current = self.detect_fleet()
 
-            # 对规则槽位，优先复用当前舰队中已存在的候选舰船。
-            reused: set[str] = set()
-            for i in range(6):
-                selector = selectors[i]
-                if selector is None:
-                    continue
-                candidates = selector.get('candidates')
-                if not isinstance(candidates, list):
-                    continue
-                chosen = next(
-                    (
-                        candidate
-                        for candidate in candidates
-                        if isinstance(candidate, str)
-                        and candidate in current
-                        and candidate not in reused
-                    ),
-                    None,
-                )
-                if chosen is not None:
-                    names[i] = chosen
-                    reused.add(chosen)
-
-            # ── 前置短路: 已满足则无需任何操作 ────────────────────────
-            if self._can_short_circuit(current, names, selectors):
+            # 当前舰队已经满足目标时，直接结束本次换船。
+            if self._validate_with_selector(current, names, selectors):
                 _log.info('[准备页] 舰队已满足目标, 跳过换船')
                 return True
 
-            # ── 2. 成员对齐: 确保目标船都在队中 ──────────────────────
-            # 先做“一对一”成员匹配：每个目标槽位最多占用一艘当前舰船，
-            # 避免宽候选槽位(如潜艇池)把整队都视为已匹配。
-            ok, matched_slots = self._match_existing_members(current, names, selectors)
+            # Step 5：第一轮执行完整对齐，重试轮只处理错误槽位。
+            # 第一次调整需要补船、删船并处理槽位压缩。
+            if attempt == 0:
+                self._full_align(current, names, selectors)
+            # 后续调整只修正 OCR 验证失败的槽位。
+            else:
+                _log.info('[准备页] 第 {} 次重试: 局部修正', attempt)
+                self._local_fix(current, names, selectors)
 
-            for i, name in enumerate(names):
-                if name is None:
-                    continue
-                if i in matched_slots:
-                    continue
-                slot = next((i for i in range(6) if not ok[i]), None)
-                if slot is None:
-                    _log.warning("[准备页] 无可用槽位放 '{}', 跳过", name)
-                    continue
-                selected_name, selected_selector = self._select_available_candidate(
-                    current,
-                    name,
-                    selectors[i],
-                    desired=names,
-                    slot_to_replace=slot,
-                )
-                if selected_name is None:
-                    _log.warning('[准备页] 槽位 {} 的候选均已在编队中, 跳过补员', i)
-                    continue
-                occupied = current[slot] is not None
-                _log.info(
-                    "[准备页] 成员对齐: 槽位 {} <- '{}' (原: '{}')",
-                    slot,
-                    selected_name,
-                    current[slot],
-                )
-                selected = self._change_single_ship(
-                    slot,
-                    selected_name,
-                    selector=selected_selector,
-                    slot_occupied=occupied,
-                )
-                current[slot] = selected if selected is not None else selected_name
-                names[i] = current[slot]
-                ok[slot] = True
-                matched_slots.add(i)
-                time.sleep(0.3)
-
-            # 从后往前移除剩余不需要的舰船
-            for i in range(5, -1, -1):
-                if not ok[i] and current[i] is not None:
-                    _log.info("[准备页] 移除槽位 {} 的 '{}'", i, current[i])
-                    self._change_single_ship(i, None, slot_occupied=True)
-                    current[i] = None
-                    time.sleep(0.3)
-
-            # 宽候选规则下，移除后可能出现“目标需要 6 船但当前仅 5 船”的情况。
-            # 这里按目标槽位进行补位，确保不会因成员压缩导致缺员。
-            current = self.detect_fleet()
-            target_count = sum(1 for v in names if v is not None)
-            current_count = sum(1 for v in current if v is not None)
-            if current_count < target_count:
-                for i, name in enumerate(names):
-                    if name is None:
-                        continue
-                    if current[i] is not None:
-                        continue
-                    selected_name, selected_selector = self._select_available_candidate(
-                        current,
-                        name,
-                        selectors[i],
-                        desired=names,
-                    )
-                    if selected_name is None:
-                        _log.warning('[准备页] 槽位 {} 的候选均已在编队中, 无法补位', i)
-                        continue
-                    _log.info(
-                        "[准备页] 成员补位: 槽位 {} <- '{}' (原: '{}')",
-                        i,
-                        selected_name,
-                        current[i],
-                    )
-                    selected = self._change_single_ship(
-                        i,
-                        selected_name,
-                        selector=selected_selector,
-                        slot_occupied=False,
-                    )
-                    current[i] = selected if selected is not None else selected_name
-                    names[i] = current[i]
-                    time.sleep(0.3)
-
-                    current_count = sum(1 for v in current if v is not None)
-                    if current_count >= target_count:
-                        break
-
-            # ── 3. 位置对齐: 滑动拖拽到正确槽位 ─────────────────────
+            # Step 6：重新识别成员，再通过拖拽调整舰船顺序。
             current = self.detect_fleet()
             self._reorder(current, names)
 
-            # ── 4. 验证结果 ──────────────────────────────────────────
+            # Step 7：最终 OCR 验证舰名、顺序、空槽和重名情况。
             current = self.detect_fleet()
+            # 最终舰队符合目标时，返回成功。
             if self._validate_with_selector(current, names, selectors):
                 _log.info('[准备页] 编成更换完成: {}', current)
                 return True
 
+            # 仍有重试次数时，等待页面稳定后进入下一轮局部修正。
             if attempt < _MAX_SET_RETRIES:
                 _log.warning(
                     '[准备页] 第 {}/{} 次验证失败, 重试...',
@@ -275,6 +154,8 @@ class FleetChangeMixin(FleetDetectMixin):
                     _MAX_SET_RETRIES + 1,
                 )
                 time.sleep(0.5)
+
+            # 所有重试都失败时，记录当前舰队并退出。
             else:
                 _log.error(
                     '[准备页] 舰队设置在 {} 次尝试后仍然失败, 当前: {}',
@@ -284,44 +165,72 @@ class FleetChangeMixin(FleetDetectMixin):
 
         return False
 
+    # 将 OCR、YAML 和选船结果中的舰名统一成可比较的标准舰名。
     @staticmethod
     def _normalize_ship_name(value: object) -> str | None:
         if value is None:
             return None
-        name = str(value).strip()
-        return name or None
 
-    @staticmethod
-    def _extract_selector(slot: object | None) -> dict | None:
+        # normalized 依次去掉空格、“·改”和尾部括号别名。
+        normalized = str(value).strip()
+        normalized = normalized.removesuffix('·改')
+        normalized = _SHIP_ALIAS_SUFFIX_RE.sub('', normalized)
+        normalized = normalized.strip()
+        return normalized or None
+
+    # 从一个槽位读取优选、备选、搜索名、舰种和等级条件。
+    @classmethod
+    def _extract_selector(cls, slot: object | None) -> dict | None:
+        """返回选船页面可以直接使用的槽位规则。"""
+        # 固定舰名和空槽没有额外选船规则。
         if slot is None or isinstance(slot, str):
             return None
 
-        raw_candidates = None
-        raw_search_name = None
-        raw_ship_type = None
-        raw_min = None
-        raw_max = None
-
+        # 字典槽位直接读取 YAML 字段。
         if isinstance(slot, dict):
             raw_candidates = slot.get('candidates')
             raw_search_name = slot.get('search_name')
             raw_ship_type = slot.get('ship_type')
             raw_min = slot.get('min_level')
             raw_max = slot.get('max_level')
+            raw_name = slot.get('name')
+        # selector 对象通过同名属性读取字段。
         else:
             raw_candidates = getattr(slot, 'candidates', None)
             raw_search_name = getattr(slot, 'search_name', None)
             raw_ship_type = getattr(slot, 'ship_type', None)
             raw_min = getattr(slot, 'min_level', None)
             raw_max = getattr(slot, 'max_level', None)
+            raw_name = getattr(slot, 'name', None)
 
-        if not isinstance(raw_candidates, list):
+        # raw_values 按“name 优先、candidates 备选”的顺序合并舰名。
+        raw_values: list[object] = []
+
+        # 有效的 name 放在候选列表首位。
+        if isinstance(raw_name, str) and raw_name.strip():
+            raw_values.append(raw_name)
+
+        # candidates 紧跟在 name 后面，保留 YAML 填写顺序。
+        if isinstance(raw_candidates, list):
+            raw_values.extend(raw_candidates)
+
+        # candidates 保存去空格后的原始舰名，交给选船页面使用。
+        candidates: list[str] = []
+
+        # seen 保存标准舰名，防止“岛风”和“岛风·改”等价项重复。
+        seen: set[str] = set()
+        for value in raw_values:
+            candidate = str(value).strip()
+            normalized = cls._normalize_ship_name(candidate)
+            if candidate and normalized and normalized not in seen:
+                candidates.append(candidate)
+                seen.add(normalized)
+
+        # 没有舰名候选时无法形成有效选船规则。
+        if not candidates:
             return None
 
-        candidates = [str(v).strip() for v in raw_candidates if str(v).strip()]
-        if len(candidates) == 0:
-            return None
-
+        # selector 是最终传给选船页面的规则。
         selector: dict[str, object] = {'candidates': candidates}
         if isinstance(raw_search_name, str) and raw_search_name.strip():
             selector['search_name'] = raw_search_name.strip()
@@ -333,29 +242,67 @@ class FleetChangeMixin(FleetDetectMixin):
             selector['max_level'] = raw_max
         return selector
 
+    # 按“已分配舰名优先、原候选随后”的顺序生成本槽候选列表。
     @classmethod
     def _slot_candidates(cls, name: str | None, selector: dict | None) -> list[str]:
         out: list[str] = []
+        seen: set[str] = set()
+        normalized_name = cls._normalize_ship_name(name)
+
+        # 已分配舰名存在时，将它放在候选列表第一位。
+        if normalized_name:
+            out.append(normalized_name)
+            seen.add(normalized_name)
+
+        # 有 selector 时，继续补充本槽位的原始候选。
         if selector is not None:
             raw = selector.get('candidates')
+
+            # candidates 必须是列表才逐项读取。
             if isinstance(raw, list):
                 for value in raw:
                     normalized = cls._normalize_ship_name(value)
-                    if normalized and normalized not in out:
+                    if normalized and normalized not in seen:
                         out.append(normalized)
-        normalized_name = cls._normalize_ship_name(name)
-        if normalized_name and normalized_name not in out:
-            out.append(normalized_name)
+                        seen.add(normalized)
         return out
 
+    # 为六个槽位挑选互不重复的目标舰名，冲突时自动尝试备选。
     @classmethod
-    def _normalize_search_name_for_compare(cls, value: str) -> str:
-        normalized = value.strip()
-        if normalized.endswith('·改'):
-            normalized = normalized.removesuffix('·改').strip()
-        normalized = _SHIP_ALIAS_SUFFIX_RE.sub('', normalized)
-        return normalized.strip()
+    def _assign_unique_targets(
+        cls,
+        names: list[str | None],
+        selectors: list[dict | None],
+    ) -> list[str | None] | None:
+        """为每个非空槽位分配唯一舰名，候选重叠时按优先级回溯。"""
+        # options 保存六个槽位各自按优先级排列的候选舰名。
+        options = [
+            cls._slot_candidates(names[i], selectors[i]) if names[i] is not None else []
+            for i in range(6)
+        ]
+        # assigned 保存回溯算法当前得到的六槽分配结果。
+        assigned: list[str | None] = [None] * 6
 
+        # 从左到右递归分配槽位，后续无解时回退并尝试当前槽位的下一个候选。
+        def assign(slot: int, used: set[str]) -> bool:
+            if slot >= 6:
+                return True
+            if names[slot] is None:
+                return assign(slot + 1, used)
+            for candidate in options[slot]:
+                if candidate in used:
+                    continue
+                assigned[slot] = candidate
+                used.add(candidate)
+                if assign(slot + 1, used):
+                    return True
+                used.remove(candidate)
+                assigned[slot] = None
+            return False
+
+        return assigned if assign(0, set()) else None
+
+    # 判断当前标准舰名是否符合 selector 指定的搜索名称。
     @classmethod
     def _matches_search_name(cls, current_name: str | None, raw_search_name: object) -> bool:
         if current_name is None:
@@ -366,21 +313,13 @@ class FleetChangeMixin(FleetDetectMixin):
             return True
 
         search_name = raw_search_name.strip()
+        # 当前舰名与搜索名完全相同时直接通过。
         if current_name == search_name:
             return True
 
-        return current_name == cls._normalize_search_name_for_compare(search_name)
+        return current_name == cls._normalize_ship_name(search_name)
 
-    @classmethod
-    def _can_short_circuit(
-        cls,
-        current: list[str | None],
-        desired: list[str | None],
-        selectors: list[dict | None],
-    ) -> bool:
-        # 对 search_name 槽位执行精确匹配，满足时可直接短路，避免准备页重复扫描。
-        return cls._validate_with_selector(current, desired, selectors)
-
+    # 从本槽候选中排除队内同名舰，并返回实际可用于选船的规则。
     @classmethod
     def _select_available_candidate(
         cls,
@@ -388,35 +327,21 @@ class FleetChangeMixin(FleetDetectMixin):
         name: str | None,
         selector: dict | None,
         *,
-        desired: list[str | None] | None = None,
         slot_to_replace: int | None = None,
     ) -> tuple[str | None, dict | None]:
-        """为槽位挑选候选舰船。
-
-        对同名舰船按“目标编队所需数量”控制占用：
-        允许同名重复编入（当目标中有多个同名槽位）,
-        但避免超过目标所需数量。
-        """
+        """返回第一个未被其他槽位占用的候选舰名。"""
+        # 目标舰名为空时，本槽不需要选船。
         if name is None:
             return None, None
 
+        # candidates 是本槽位按优先级排列的标准舰名。
         candidates = cls._slot_candidates(name, selector)
-        occupied_counts = Counter(
+        # occupied 保存队内其他槽位已经占用的舰名。
+        occupied = {
             ship for idx, ship in enumerate(current) if ship is not None and idx != slot_to_replace
-        )
-
-        required_counts: Counter[str]
-        if desired is None:
-            required_counts = Counter()
-        else:
-            required_counts = Counter(ship for ship in desired if ship is not None)
-
-        available: list[str] = []
-        for candidate in candidates:
-            required = required_counts.get(candidate, 1)
-            occupied = occupied_counts.get(candidate, 0)
-            if occupied < required:
-                available.append(candidate)
+        }
+        # available 保留当前舰队中尚未占用的候选。
+        available = [candidate for candidate in candidates if candidate not in occupied]
 
         if len(available) == 0:
             return None, None
@@ -425,12 +350,14 @@ class FleetChangeMixin(FleetDetectMixin):
         if selector is None:
             return chosen, None
 
+        # narrowed_selector 只把未占用候选交给选船页面。
         narrowed_selector = dict(selector)
         narrowed_selector['candidates'] = available
         return chosen, narrowed_selector
 
+    # 将当前舰队成员与目标槽位一对一匹配，找出可以直接保留的舰船。
     @classmethod
-    def _match_existing_members(  # noqa: PLR0912
+    def _match_existing_members(
         cls,
         current: list[str | None],
         desired: list[str | None],
@@ -443,52 +370,40 @@ class FleetChangeMixin(FleetDetectMixin):
         - matched_slots: 哪些目标槽位已由当前舰队中的舰船满足
         """
         ok: list[bool] = [False] * 6
+        # matched_slots 保存已经找到舰船的目标槽位。
         matched_slots: set[int] = set()
+        # used_positions 防止同一艘当前舰船匹配多个目标槽位。
         used_positions: set[int] = set()
 
-        slot_candidates: dict[int, list[str]] = {}
-        for i in range(6):
-            if desired[i] is None:
-                continue
-            slot_candidates[i] = cls._slot_candidates(desired[i], selectors[i])
+        # target_slots 只包含需要舰船的目标槽位。
+        target_slots = [i for i, name in enumerate(desired) if name is not None]
 
-        # 第一轮: 同槽位优先，尽量减少后续拖拽/换船。
-        for i, candidates in slot_candidates.items():
-            ship = current[i]
-            if ship is None:
-                continue
-            if ship in candidates:
-                selector = selectors[i]
-                if isinstance(selector, dict):
-                    raw_search_name = selector.get('search_name')
-                    # 指定了搜索关键词时，不能仅凭同名判定已满足。
-                    if (
-                        isinstance(raw_search_name, str)
-                        and raw_search_name.strip()
-                        and not cls._matches_search_name(ship, raw_search_name)
-                    ):
-                        continue
+        # 判断一艘当前舰船能否满足指定目标槽位。
+        def matches(slot: int, ship: str | None) -> bool:
+            selector = selectors[slot]
+            return ship == desired[slot] and (
+                selector is None or cls._matches_search_name(ship, selector.get('search_name'))
+            )
+
+        # 第一轮优先保留已经位于正确槽位的舰船。
+        for i in target_slots:
+            # 当前槽位已经符合目标时，将当前位置和目标槽位同时标记为已匹配。
+            if matches(i, current[i]):
                 ok[i] = True
                 matched_slots.add(i)
                 used_positions.add(i)
 
-        # 第二轮: 跨槽位补匹配，仍保持“一目标槽位只匹配一艘船”。
-        for i, candidates in slot_candidates.items():
+        # 第二轮在其他位置寻找目标舰船，后续再通过拖拽调整顺序。
+        for i in target_slots:
+            # 第一轮已经满足的目标槽位无需再次查找。
             if i in matched_slots:
                 continue
             for j, ship in enumerate(current):
-                if j in used_positions or ship is None:
+                # 已经匹配过的当前位置不能重复使用。
+                if j in used_positions:
                     continue
-                if ship in candidates:
-                    selector = selectors[i]
-                    if isinstance(selector, dict):
-                        raw_search_name = selector.get('search_name')
-                        if (
-                            isinstance(raw_search_name, str)
-                            and raw_search_name.strip()
-                            and not cls._matches_search_name(ship, raw_search_name)
-                        ):
-                            continue
+                # 找到符合目标的舰船后，记录匹配并停止搜索本目标槽位。
+                if matches(i, ship):
                     ok[j] = True
                     matched_slots.add(i)
                     used_positions.add(j)
@@ -496,6 +411,25 @@ class FleetChangeMixin(FleetDetectMixin):
 
         return ok, matched_slots
 
+    # 判断一个当前槽位是否满足对应的目标舰名和搜索规则。
+    @classmethod
+    def _slot_matches(
+        cls,
+        current_name: str | None,
+        target: str | None,
+        selector: dict | None,
+    ) -> bool:
+        # 目标为空时，只有当前槽也为空才算匹配。
+        if target is None:
+            return current_name is None
+        if selector is None:
+            return current_name == target
+        return cls._matches_search_name(
+            current_name,
+            selector.get('search_name'),
+        ) and current_name in cls._slot_candidates(target, selector)
+
+    # 验证当前六个槽位是否完整满足目标，并拒绝队内同名舰。
     @classmethod
     def _validate_with_selector(
         cls,
@@ -503,63 +437,164 @@ class FleetChangeMixin(FleetDetectMixin):
         desired: list[str | None],
         selectors: list[dict | None],
     ) -> bool:
-        for i in range(6):
-            target = desired[i]
-            selector = selectors[i]
-            current_name = current[i]
-            if target is None:
+        members = [name for name in current if name is not None]
+        if len(members) != len(set(members)):
+            return False
+
+        return all(cls._slot_matches(current[i], desired[i], selectors[i]) for i in range(6))
+
+    # 找出当前舰队中需要替换、补充或移除的槽位。
+    @classmethod
+    def _find_wrong_slots(
+        cls,
+        current: list[str | None],
+        names: list[str | None],
+        selectors: list[dict | None],
+    ) -> list[int]:
+        """返回所有不符合目标规则的槽位下标。"""
+        return [i for i in range(6) if not cls._slot_matches(current[i], names[i], selectors[i])]
+
+    # 为一个目标槽位选择舰船，并同步更新当前舰队和目标舰名。
+    def _replace_target(
+        self,
+        current: list[str | None],
+        names: list[str | None],
+        selectors: list[dict | None],
+        target_slot: int,
+        ship_slot: int | None = None,
+    ) -> None:
+        """选择目标舰船，并更新当前舰队和目标舰名。"""
+        target = names[target_slot]
+        assert target is not None
+        slot = target_slot if ship_slot is None else ship_slot
+        selected_name, selected_selector = self._select_available_candidate(
+            current,
+            target,
+            selectors[target_slot],
+            slot_to_replace=slot,
+        )
+        # 本槽所有候选都被占用时，无法组成目标舰队。
+        if selected_name is None:
+            raise RuntimeError(f'目标槽位 {target_slot} 没有未被占用的候选舰船')
+
+        _log.info(
+            "[准备页] 更换槽位 {} <- '{}' (原: '{}')",
+            slot,
+            selected_name,
+            current[slot],
+        )
+        selected = self._change_single_ship(
+            slot,
+            selected_name,
+            selector=selected_selector,
+            slot_occupied=current[slot] is not None,
+        )
+        actual = selected if selected is not None else selected_name
+        current[slot] = actual
+        names[target_slot] = actual
+        time.sleep(0.3)
+
+    # 首次调整时完成成员复用、缺员补充、多余成员移除和压缩后补位。
+    def _full_align(
+        self,
+        current: list[str | None],
+        names: list[str | None],
+        selectors: list[dict | None],
+    ) -> None:
+        """首次将当前成员调整成目标成员集合。"""
+        # ok 标记当前可保留位置，matched_slots 标记已满足的目标槽位。
+        ok, matched_slots = self._match_existing_members(current, names, selectors)
+
+        # Step 1：把尚未满足的目标舰船放入可替换槽位。
+        for i, name in enumerate(names):
+            if name is None:
                 continue
-            if selector is None:
-                if current_name != target:
-                    return False
+            if i in matched_slots:
                 continue
+            # slot 是当前舰队中第一个不能保留、可以用于替换的位置。
+            slot = next((idx for idx in range(6) if not ok[idx]), None)
+            if slot is None:
+                raise RuntimeError(f"无可用槽位放置目标舰船 '{name}'")
+            self._replace_target(current, names, selectors, i, slot)
+            ok[slot] = True
+            matched_slots.add(i)
 
-            raw_search_name = selector.get('search_name')
-            if (
-                isinstance(raw_search_name, str)
-                and raw_search_name.strip()
-                and not cls._matches_search_name(current_name, raw_search_name)
-            ):
-                return False
+        # Step 2：从后往前移除剩余多余舰船，减少槽位压缩影响。
+        for i in range(5, -1, -1):
+            # 当前位置不能保留且仍有舰船时，将该舰船移除。
+            if not ok[i] and current[i] is not None:
+                _log.info("[准备页] 移除槽位 {} 的 '{}'", i, current[i])
+                self._change_single_ship(i, None, slot_occupied=True)
+                current[i] = None
+                time.sleep(0.3)
 
-            candidates = selector.get('candidates')
-            if not isinstance(candidates, list):
-                if current_name != target:
-                    return False
+        # Step 3：重新 OCR，检查删除舰船造成的槽位压缩和缺员。
+        current[:] = self.detect_fleet()
+        target_count = sum(1 for v in names if v is not None)
+        current_count = sum(1 for v in current if v is not None)
+        # 实际舰船少于目标数量时，逐槽补齐缺少成员。
+        if current_count < target_count:
+            for i, name in enumerate(names):
+                if name is None:
+                    continue
+                if current[i] is not None:
+                    continue
+                self._replace_target(current, names, selectors, i)
+
+                current_count = sum(1 for v in current if v is not None)
+                if current_count >= target_count:
+                    break
+
+    # OCR 验证失败后，只替换或移除不符合目标的槽位。
+    def _local_fix(
+        self,
+        current: list[str | None],
+        names: list[str | None],
+        selectors: list[dict | None],
+    ) -> None:
+        """只修正本轮识别出的错误槽位。"""
+        # wrong 保存所有需要替换、补充或移除的槽位。
+        wrong = self._find_wrong_slots(current, names, selectors)
+        if not wrong:
+            return
+
+        _log.info('[准备页] 局部修正: 错误槽位 {}', wrong)
+
+        # 先完成替换/补员，再移除多余舰船。1 队只剩最后一艘时，
+        # 这能保证槽位 0 直接替换，不会先进入空队状态。
+        replacement_slots = [i for i in wrong if names[i] is not None]
+        removal_slots = [i for i in wrong if names[i] is None]
+
+        # Step 1：先替换和补船，避免一队在移除时变成空队。
+        for i in replacement_slots:
+            self._replace_target(current, names, selectors, i)
+
+        # Step 2：再从后往前移除目标为空的多余舰船。
+        for i in reversed(removal_slots):
+            # 当前槽位已经为空时，不重复进入选船页面。
+            if current[i] is None:
                 continue
-            if current_name not in candidates:
-                return False
-        return True
+            _log.info("[准备页] 局部修正: 移除槽位 {} 的 '{}'", i, current[i])
+            self._change_single_ship(i, None, slot_occupied=True)
+            current[i] = None
+            time.sleep(0.3)
 
-    # ══════════════════════════════════════════════════════════════════════
-    # 位置对齐
-    # ══════════════════════════════════════════════════════════════════════
-
+    # 从左到右拖拽舰船，使当前舰队顺序与目标槽位一致。
     def _reorder(
         self,
         current: list[str | None],
         desired: list[str | None],
     ) -> None:
-        """通过滑动将舰船移至目标位置 (对齐 legacy ``Fleet.reorder``)。
-
-        从左到右逐槽位检查, 若当前位置不是目标船则找到目标船所在
-        槽位, 通过 ``_circular_move`` 滑动到正确位置。
-
-        Parameters
-        ----------
-        current:
-            **变参**: 当前 6 槽位舰船名, 本方法会就地修改。
-        desired:
-            目标 6 槽位舰船名。
-        """
+        """通过拖拽调整舰船顺序，并同步更新 current。"""
         for i in range(6):
             target = desired[i]
             if target is None:
-                break  # 对齐 legacy: 遇到空位即停止
+                break
             if current[i] == target:
                 continue
             try:
                 src = current.index(target)
+            # 当前舰队中找不到目标舰船时，保留现场交给最终验证处理。
             except ValueError:
                 _log.warning(
                     "[准备页] 位置对齐: '{}' 不在当前舰队中, 跳过",
@@ -574,40 +609,28 @@ class FleetChangeMixin(FleetDetectMixin):
             )
             self._circular_move(src, i, current)
 
+    # 将一艘舰船从源槽位拖到目标槽位，并模拟游戏中的循环位移。
     def _circular_move(
         self,
         src: int,
         dst: int,
         current: list[str | None],
     ) -> None:
-        """滑动将舰船从 *src* 槽位移至 *dst* 槽位。
-
-        游戏行为: 拖拽 src 到 dst 后, src 与 dst 之间的舰船做循环位移。
-
-        Parameters
-        ----------
-        src:
-            源槽位 (0-5)。
-        dst:
-            目标槽位 (0-5)。
-        current:
-            **变参**: 当前 6 槽位舰船名, 就地更新以反映移动后状态。
-        """
+        """执行一次拖拽，并更新内存中的舰队顺序。"""
+        # 源槽位和目标槽位相同时，不需要执行拖拽。
         if src == dst:
             return
+        # sx、sy 是源槽位坐标，dx、dy 是目标槽位坐标。
         sx, sy = CLICK_SHIP_SLOT[src]
         dx, dy = CLICK_SHIP_SLOT[dst]
         self._ctrl.swipe(sx, sy, dx, dy, duration=0.5)
 
-        # 更新本地追踪 (circular shift, 对齐 legacy)
+        # ship 是从源槽位取出的舰名，用于同步游戏中的循环位移。
         ship = current.pop(src)
         current.insert(dst, ship)
         time.sleep(0.5)
 
-    # ══════════════════════════════════════════════════════════════════════
-    # 单船更换
-    # ══════════════════════════════════════════════════════════════════════
-
+    # 打开指定槽位的选船页面，完成单艘舰船的选择或移除。
     def _change_single_ship(
         self,
         slot: int,
@@ -616,18 +639,15 @@ class FleetChangeMixin(FleetDetectMixin):
         selector: dict | None = None,
         slot_occupied: bool = True,
     ) -> str | None:
-        """更换/移除指定位置的单艘舰船。
-
-        点击槽位 -> 进入选船页面 -> 委托给
-        :meth:`~autowsgr.ui.choose_ship_page.ChooseShipPage.change_single_ship`
-        完成实际操作 (根据 ``_use_search`` 决定是否使用搜索框)。
-        """
+        """返回选船页面实际选中的舰名。"""
         from autowsgr.ui.choose_ship_page import ChooseShipPage
         from autowsgr.ui.utils import wait_for_page
 
+        # 目标为空且当前槽位也为空时，不需要打开选船页面。
         if name is None and not slot_occupied:
             return None
 
+        # 点击目标槽位并等待选船页面加载完成。
         self.click_ship_slot(slot)
         wait_for_page(
             self._ctrl,
@@ -636,6 +656,7 @@ class FleetChangeMixin(FleetDetectMixin):
             source='编队',
             target='编队选船',
         )
+        # choose_page 负责根据舰名、舰种和等级条件执行实际选船。
         choose_page = ChooseShipPage(self._ctx)
         return choose_page.change_single_ship(
             name,

--- a/testing/ops/test_normal_fight_unit.py
+++ b/testing/ops/test_normal_fight_unit.py
@@ -8,8 +8,11 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from autowsgr.combat import CombatMode, CombatPlan
-from autowsgr.ops.normal_fight import NormalFightRunner
+from autowsgr.infra import ActionFailedError
+from autowsgr.ops.normal_fight import NormalFightRunner, _require_fleet_change
 
 
 def _make_ctx() -> SimpleNamespace:
@@ -21,6 +24,15 @@ def _make_ctx() -> SimpleNamespace:
 
     cfg = SimpleNamespace(dock_full_destroy=False, destroy_ship_types=None)
     return SimpleNamespace(ctrl=None, config=cfg)
+
+
+class TestFleetChangeResult:
+    def test_success_continues(self):
+        _require_fleet_change(True, 'fleet')
+
+    def test_failure_stops_fight(self):
+        with pytest.raises(ActionFailedError, match='fleet 编队失败'):
+            _require_fleet_change(False, 'fleet')
 
 
 class TestEventNormalMerge:

--- a/testing/ui/battle_preparation/test_unit.py
+++ b/testing/ui/battle_preparation/test_unit.py
@@ -359,3 +359,268 @@ class TestDecisiveFleetChangeFeatureGate:
             assert page.change_fleet(None, ['A'])
 
         new_change.assert_called_once_with(None, ['A'])
+
+
+# ─────────────────────────────────────────────
+# 智能换船
+# ─────────────────────────────────────────────
+
+
+class TestSmartFleetChange:
+    def test_first_fleet_replaces_before_removing_extra_ship(self):
+        """1 队从 AB 改为 C 时，先替换槽位 0，再移除 B。"""
+        page = BattlePreparationPage(_make_ctx(MagicMock(spec=AndroidController)))
+        fleet_a_b = ['A', 'B', None, None, None, None]
+        fleet_c = ['C', None, None, None, None, None]
+
+        with (
+            patch.object(page, 'get_selected_fleet', return_value=1),
+            patch.object(
+                page,
+                'detect_fleet',
+                side_effect=[fleet_a_b, fleet_c, fleet_c, fleet_c],
+            ) as detect,
+            patch.object(
+                page,
+                '_change_single_ship',
+                side_effect=['C', None],
+            ) as change_ship,
+            patch('autowsgr.ui.battle.fleet_change._change.time.sleep'),
+        ):
+            assert page.change_fleet(1, ['C'])
+
+        actions = [
+            (item.args[0], item.args[1], item.kwargs['slot_occupied'])
+            for item in change_ship.call_args_list
+        ]
+        assert actions == [(0, 'C', True), (1, None, True)]
+        assert all(not item.args and not item.kwargs for item in detect.call_args_list)
+
+    def test_first_fleet_slot_zero_cannot_be_empty(self):
+        page = BattlePreparationPage(_make_ctx(MagicMock(spec=AndroidController)))
+
+        with (
+            patch.object(page, 'get_selected_fleet', return_value=1),
+            pytest.raises(ValueError, match='1 队槽位 0 不能为空'),
+        ):
+            page.change_fleet(1, [None, 'B'])
+
+    def test_input_over_six_slots_is_truncated(self):
+        page = BattlePreparationPage(_make_ctx(MagicMock(spec=AndroidController)))
+        target = ['A', 'B', 'C', 'D', 'E', 'F']
+
+        with patch.object(page, 'detect_fleet', return_value=target) as detect:
+            assert page.change_fleet(None, [*target, 'G'])
+
+        detect.assert_called_once_with()
+
+    def test_duplicate_fixed_names_fail_before_ocr(self):
+        page = BattlePreparationPage(_make_ctx(MagicMock(spec=AndroidController)))
+
+        with patch.object(page, 'detect_fleet') as detect:
+            assert not page.change_fleet(None, ['A', 'A'])
+
+        detect.assert_not_called()
+
+    def test_failed_verification_uses_two_local_retries(self):
+        page = BattlePreparationPage(_make_ctx(MagicMock(spec=AndroidController)))
+        wrong = ['X', None, None, None, None, None]
+
+        with (
+            patch.object(page, 'detect_fleet', return_value=wrong),
+            patch.object(page, '_full_align') as full_align,
+            patch.object(page, '_local_fix') as local_fix,
+            patch.object(page, '_reorder'),
+            patch('autowsgr.ui.battle.fleet_change._change.time.sleep'),
+        ):
+            assert not page.change_fleet(None, ['A'])
+
+        assert full_align.call_count == 1
+        assert local_fix.call_count == 2
+
+
+class TestFleetSlotRules:
+    @pytest.mark.parametrize(
+        ('raw', 'expected'),
+        [
+            (None, None),
+            ('  岛风  ', '岛风'),
+            ('岛风·改', '岛风'),
+            ('飞龙（苍青幻影）', '飞龙'),
+            ('', None),
+        ],
+    )
+    def test_normalize_ship_name(self, raw: object, expected: str | None):
+        assert BattlePreparationPage._normalize_ship_name(raw) == expected
+
+    def test_name_and_candidates_form_one_slot_rule(self):
+        selector = BattlePreparationPage._extract_selector(
+            {
+                'name': '密苏里',
+                'candidates': ['衣阿华', '密苏里'],
+                'ship_type': 'BB',
+                'min_level': 100,
+                'max_level': 110,
+            },
+        )
+
+        assert selector == {
+            'candidates': ['密苏里', '衣阿华'],
+            'ship_type': 'bb',
+            'min_level': 100,
+            'max_level': 110,
+        }
+
+    def test_overlapping_priorities_use_backtracking(self):
+        names = ['A', 'A', None, None, None, None]
+        selectors: list[dict | None] = [
+            {'candidates': ['A', 'B']},
+            {'candidates': ['A']},
+            None,
+            None,
+            None,
+            None,
+        ]
+
+        assert BattlePreparationPage._assign_unique_targets(names, selectors) == [
+            'B',
+            'A',
+            None,
+            None,
+            None,
+            None,
+        ]
+
+    def test_same_candidate_in_two_slots_is_impossible(self):
+        names = ['岛风', '岛风', None, None, None, None]
+        selectors: list[dict | None] = [
+            {'candidates': ['岛风']},
+            {'candidates': ['岛风']},
+            None,
+            None,
+            None,
+            None,
+        ]
+
+        assert BattlePreparationPage._assign_unique_targets(names, selectors) is None
+
+    def test_occupied_name_is_removed_from_slot_candidates(self):
+        selected, selector = BattlePreparationPage._select_available_candidate(
+            ['岛风', None, None, None, None, None],
+            '岛风',
+            {'candidates': ['岛风', '雪风']},
+        )
+
+        assert selected == '雪风'
+        assert selector is not None
+        assert selector['candidates'] == ['雪风']
+
+    def test_replacing_same_slot_may_keep_current_name(self):
+        selected, _selector = BattlePreparationPage._select_available_candidate(
+            ['岛风', None, None, None, None, None],
+            '岛风',
+            {'candidates': ['岛风', '雪风']},
+            slot_to_replace=0,
+        )
+
+        assert selected == '岛风'
+
+    def test_existing_members_are_matched_only_once(self):
+        current = ['炽热', '絮弗伦', '岛风', '黑潮', None, None]
+        desired = ['岛风', '黑潮', '阳炎', '早春', '吹雪', '初夏']
+        shared = ['岛风', '黑潮', '阳炎', '早春', '吹雪', '初夏']
+        selectors: list[dict | None] = [
+            {'candidates': ['岛风']},
+            *[{'candidates': shared} for _ in range(5)],
+        ]
+
+        ok, matched_slots = BattlePreparationPage._match_existing_members(
+            current,
+            desired,
+            selectors,
+        )
+
+        assert matched_slots == {0, 1}
+        assert ok == [False, False, True, True, False, False]
+
+    def test_final_validation_rejects_duplicate_names(self):
+        current = ['岛风', '岛风', None, None, None, None]
+
+        assert not BattlePreparationPage._validate_with_selector(
+            current,
+            current,
+            [None] * 6,
+        )
+
+    def test_find_wrong_slots(self):
+        current = ['X', 'B', 'Y', None, 'E', None]
+        desired = ['A', 'B', 'C', None, None, None]
+
+        assert BattlePreparationPage._find_wrong_slots(
+            current,
+            desired,
+            [None] * 6,
+        ) == [0, 2, 4]
+
+
+class TestFleetAlignment:
+    def test_slot_failure_does_not_borrow_another_slot_candidates(self):
+        page = BattlePreparationPage(_make_ctx(MagicMock(spec=AndroidController)))
+        current = [None] * 6
+        names = ['契卡洛夫', '岛风', None, None, None, None]
+        selectors: list[dict | None] = [
+            {'candidates': ['契卡洛夫'], 'min_level': 100},
+            {'candidates': ['岛风', '黑潮'], 'min_level': 100},
+            None,
+            None,
+            None,
+            None,
+        ]
+
+        with (
+            patch.object(
+                page,
+                '_change_single_ship',
+                side_effect=RuntimeError('未找到契卡洛夫'),
+            ) as change_ship,
+            pytest.raises(RuntimeError, match='契卡洛夫'),
+        ):
+            page._full_align(current, names, selectors)
+
+        assert change_ship.call_count == 1
+        assert change_ship.call_args.args == (0, '契卡洛夫')
+        assert change_ship.call_args.kwargs['selector']['candidates'] == ['契卡洛夫']
+
+    def test_local_fix_replaces_before_removing(self):
+        page = BattlePreparationPage(_make_ctx(MagicMock(spec=AndroidController)))
+        current = ['A', 'X', 'C', 'D', None, None]
+        desired = ['A', 'B', 'C', None, None, None]
+        actions: list[str] = []
+
+        with (
+            patch.object(
+                page,
+                '_replace_target',
+                side_effect=lambda *_args: actions.append('replace'),
+            ),
+            patch.object(
+                page,
+                '_change_single_ship',
+                side_effect=lambda *_args, **_kwargs: actions.append('remove'),
+            ),
+            patch('autowsgr.ui.battle.fleet_change._change.time.sleep'),
+        ):
+            page._local_fix(current, desired, [None] * 6)
+
+        assert actions == ['replace', 'remove']
+
+    def test_reorder_moves_existing_ship(self):
+        ctrl = MagicMock(spec=AndroidController)
+        page = BattlePreparationPage(_make_ctx(ctrl))
+        current = ['B', 'A', None, None, None, None]
+
+        with patch('autowsgr.ui.battle.fleet_change._change.time.sleep'):
+            page._reorder(current, ['A', 'B', None, None, None, None])
+
+        assert current == ['A', 'B', None, None, None, None]
+        ctrl.swipe.assert_called_once()


### PR DESCRIPTION
## 改动

- 使用了全新逻辑实现智能识别换船
- 支持每个槽位独立的主选、备选、舰种和等级条件。
- 使用回溯分配互不重复的目标舰名，避免同名舰进入同一舰队。
- 首轮完整对齐后仅修正错误槽位；1 队先换入目标舰再移除多余舰，避免槽位 0 为空。
- 兼容同时期改动：`NormalFightRunner` 在换船失败时立即停止出征；`EventFightRunner` 通过继承自动复用该行为。

## 范围

- 继续使用现有无参数 `detect_fleet()`，本 PR 不包含新的 OCR 识别逻辑，OCR配套改动在之后的feat进行pr
- 不修改 `event_fight.py`，保留上游活动战继承结构。
- 不包含 YAML 解析、等级 OCR 或 feat 文档改动。

## 测试

- 目前个人周常1-1到10-1的任务可以连续跑通，并且进行了 6小时 630船随机替换稳定性测试
- `uv run pytest testing/ui/battle_preparation/test_unit.py testing/ops/test_normal_fight_unit.py -q`：67 passed
- Ruff check：通过
- Ruff format check：通过