### PR TITLE
fix(server): make task outcomes and shutdown explicit

### DIFF
--- a/autowsgr/server/routes/system.py
+++ b/autowsgr/server/routes/system.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from fastapi import APIRouter
 from pydantic import BaseModel
 
@@ -15,6 +17,7 @@ from .. import main as _main
 _log = get_logger('server')
 
 router = APIRouter(prefix='/api/system', tags=['system'])
+_TASK_STOP_TIMEOUT_SECONDS = 30.0
 
 
 class SystemStartRequest(BaseModel):
@@ -52,6 +55,16 @@ async def system_stop() -> ApiResponse:
 
     if task_manager.is_running:
         task_manager.stop_task()
+        completed = await asyncio.to_thread(
+            task_manager.wait_for_completion,
+            _TASK_STOP_TIMEOUT_SECONDS,
+        )
+        if not completed:
+            _log.error('[System] 任务未在超时前停止, 保留当前系统上下文')
+            return ApiResponse(
+                success=False,
+                error='任务未在超时前停止，系统上下文仍保持活动状态',
+            )
 
     _main._ctx = None
     _log.info('[System] 系统已停止')
@@ -82,8 +95,6 @@ async def emulator_devices() -> ApiResponse:
 
     会先对已知 TCP serial（MuMu 等）执行 adb connect，再列出设备。
     """
-    import asyncio
-
     try:
         from autowsgr.emulator.detector import connect_and_list_devices
 

--- a/autowsgr/server/routes/task.py
+++ b/autowsgr/server/routes/task.py
@@ -17,7 +17,7 @@ from autowsgr.server.schemas import (
     NormalFightRequest,
 )
 from autowsgr.server.serializers import build_combat_plan, convert_combat_result
-from autowsgr.server.task_manager import task_manager
+from autowsgr.server.task_manager import TaskOutcome, task_manager
 
 from ..main import get_context
 
@@ -97,7 +97,7 @@ async def _start_normal_fight(ctx: Any, request: NormalFightRequest) -> ApiRespo
     from autowsgr.combat import CombatPlan
     from autowsgr.ops import run_normal_fight
 
-    def executor(_task_info: Any) -> list[dict[str, Any]]:
+    def executor(_task_info: Any) -> TaskOutcome:
         results = []
 
         if request.plan_id:
@@ -135,7 +135,7 @@ async def _start_normal_fight(ctx: Any, request: NormalFightRequest) -> ApiRespo
                 _log.error('[Task] 第 {} 轮失败: {}', i + 1, e)
                 results.append({'round': i + 1, 'success': False, 'error': str(e)})
 
-        return results
+        return TaskOutcome.from_results(results)
 
     task_id = task_manager.start_task(
         task_type='normal_fight',
@@ -155,7 +155,7 @@ async def _start_event_fight(ctx: Any, request: EventFightRequest) -> ApiRespons
     from autowsgr.combat import CombatPlan
     from autowsgr.ops import run_event_fight
 
-    def executor(_task_info: Any) -> list[dict[str, Any]]:
+    def executor(_task_info: Any) -> TaskOutcome:
         results = []
 
         if request.plan_id:
@@ -198,7 +198,7 @@ async def _start_event_fight(ctx: Any, request: EventFightRequest) -> ApiRespons
                 _log.error('[Task] 第 {} 轮失败: {}', i + 1, e)
                 results.append({'round': i + 1, 'success': False, 'error': str(e)})
 
-        return results
+        return TaskOutcome.from_results(results)
 
     task_id = task_manager.start_task(
         task_type='event_fight',
@@ -217,7 +217,7 @@ async def _start_campaign(ctx: Any, request: CampaignRequest) -> ApiResponse:
     """启动战役任务。"""
     from autowsgr.ops import CampaignRunner
 
-    def executor(_task_info: Any) -> list[dict[str, Any]]:
+    def executor(_task_info: Any) -> TaskOutcome:
         runner = CampaignRunner(
             ctx,
             campaign_name=request.campaign_name,
@@ -242,7 +242,7 @@ async def _start_campaign(ctx: Any, request: CampaignRequest) -> ApiResponse:
                 _log.error('[Task] 第 {} 轮失败: {}', i + 1, e)
                 results.append({'round': i + 1, 'success': False, 'error': str(e)})
 
-        return results
+        return TaskOutcome.from_results(results)
 
     task_id = task_manager.start_task(
         task_type='campaign',
@@ -261,15 +261,17 @@ async def _start_exercise(ctx: Any, request: ExerciseRequest) -> ApiResponse:
     """启动演习任务。"""
     from autowsgr.ops import ExerciseRunner
 
-    def executor(_task_info: Any) -> list[dict[str, Any]]:
+    def executor(_task_info: Any) -> TaskOutcome:
         runner = ExerciseRunner(ctx, fleet_id=request.fleet_id)
         task_manager.update_progress(current_round=1, current_node='演习')
 
         try:
             results = runner.run()
-            return [convert_combat_result(r, i + 1) for i, r in enumerate(results)]
+            return TaskOutcome.from_results(
+                [convert_combat_result(r, i + 1) for i, r in enumerate(results)]
+            )
         except Exception as e:
-            return [{'round': 1, 'success': False, 'error': str(e)}]
+            return TaskOutcome.from_results([{'round': 1, 'success': False, 'error': str(e)}])
 
     task_id = task_manager.start_task(
         task_type='exercise',
@@ -289,7 +291,7 @@ async def _start_decisive(ctx: Any, request: DecisiveRequest) -> ApiResponse:
     from autowsgr.infra import DecisiveConfig
     from autowsgr.ops import DecisiveController
 
-    def executor(_task_info: Any) -> list[dict[str, Any]]:
+    def executor(_task_info: Any) -> TaskOutcome:
         config = DecisiveConfig(
             chapter=request.chapter,
             decisive_rounds=request.decisive_rounds,
@@ -321,7 +323,7 @@ async def _start_decisive(ctx: Any, request: DecisiveRequest) -> ApiResponse:
         except Exception as e:
             results.append({'round': len(results) + 1, 'success': False, 'error': str(e)})
 
-        return results
+        return TaskOutcome.from_results(results)
 
     task_id = task_manager.start_task(
         task_type='decisive',

--- a/autowsgr/server/routes/task.py
+++ b/autowsgr/server/routes/task.py
@@ -44,7 +44,7 @@ async def task_start(request: TaskRequestUnion) -> ApiResponse:  # type: ignore[
     except RuntimeError as e:
         raise HTTPException(status_code=503, detail=str(e)) from e
 
-    ctx.stop_event = task_manager._stop_event
+    ctx.stop_event = task_manager.stop_event
 
     if isinstance(request, NormalFightRequest):
         return await _start_normal_fight(ctx, request)

--- a/autowsgr/server/task_manager.py
+++ b/autowsgr/server/task_manager.py
@@ -124,6 +124,11 @@ class TaskManager:
         """是否有任务正在运行。"""
         return self._current_task is not None and self._current_task.status == TaskStatus.RUNNING
 
+    @property
+    def stop_event(self) -> threading.Event:
+        """任务执行使用的协作式停止信号。"""
+        return self._stop_event
+
     def set_loop(self, loop: asyncio.AbstractEventLoop) -> None:
         """设置事件循环引用，用于从线程中调用 async 函数。"""
         self._loop = loop

--- a/autowsgr/server/task_manager.py
+++ b/autowsgr/server/task_manager.py
@@ -31,6 +31,33 @@ class TaskStatus(Enum):
     STOPPED = 'stopped'
 
 
+@dataclass(frozen=True)
+class TaskOutcome:
+    """任务执行器的最终结果。
+
+    执行器应当把每轮结果完整返回，并显式表达任务整体是否成功。这样
+    ``TaskManager`` 无须根据“executor 是否抛异常”猜测业务结果。
+    """
+
+    results: list[dict[str, Any]]
+    success: bool
+    error: str | None = None
+
+    @classmethod
+    def from_results(cls, results: list[dict[str, Any]]) -> TaskOutcome:
+        """根据逐轮结果构建任务结果。"""
+        failed_results = [result for result in results if not result.get('success', False)]
+        if failed_results:
+            error = next(
+                (str(result['error']) for result in failed_results if result.get('error')),
+                '一个或多个任务轮次失败',
+            )
+            return cls(results=results, success=False, error=error)
+        if not results:
+            return cls(results=[], success=False, error='任务未执行任何轮次')
+        return cls(results=results, success=True)
+
+
 @dataclass
 class TaskInfo:
     """任务信息。"""
@@ -105,7 +132,7 @@ class TaskManager:
         self,
         task_type: str,
         total_rounds: int,
-        executor: Callable[[TaskInfo], list[dict[str, Any]]],
+        executor: Callable[[TaskInfo], TaskOutcome],
     ) -> str:
         """启动新任务。
 
@@ -116,7 +143,7 @@ class TaskManager:
         total_rounds:
             总轮次
         executor:
-            执行函数，接收 TaskInfo，返回结果列表
+            执行函数，接收 TaskInfo，返回显式任务结果
 
         Returns
         -------
@@ -150,21 +177,24 @@ class TaskManager:
 
     def _run_in_thread(
         self,
-        executor: Callable[[TaskInfo], list[dict[str, Any]]],
+        executor: Callable[[TaskInfo], TaskOutcome],
     ) -> None:
         """在后台线程中执行任务。"""
         assert self._current_task is not None
         task = self._current_task
 
         try:
-            results = executor(task)
+            outcome = executor(task)
+            task.results = outcome.results
 
             # 检查是否被请求停止
             if task.stop_requested:
                 task.status = TaskStatus.STOPPED
-            else:
+            elif outcome.success:
                 task.status = TaskStatus.COMPLETED
-                task.results = results
+            else:
+                task.status = TaskStatus.FAILED
+                task.error = outcome.error
 
             task.finished_at = datetime.now(UTC).isoformat()
             _log.info('[Task] 任务完成: {} ({})', task.task_id, task.status.value)
@@ -186,7 +216,11 @@ class TaskManager:
     async def _notify_completion(self, task: TaskInfo) -> None:
         """发送任务完成通知。"""
         success = task.status == TaskStatus.COMPLETED
-        result = task.result_summary if success else None
+        result = (
+            task.result_summary
+            if task.status in (TaskStatus.COMPLETED, TaskStatus.FAILED)
+            else None
+        )
         await ws_manager.send_task_completed(
             task_id=task.task_id,
             success=success,
@@ -254,8 +288,8 @@ class TaskManager:
 
         task = self._current_task
         result = None
-        if task.status in (TaskStatus.COMPLETED, TaskStatus.FAILED, TaskStatus.STOPPED):
-            result = task.result_summary if task.status == TaskStatus.COMPLETED else None
+        if task.status in (TaskStatus.COMPLETED, TaskStatus.FAILED):
+            result = task.result_summary
 
         return {
             'task_id': task.task_id,

--- a/autowsgr/server/task_manager.py
+++ b/autowsgr/server/task_manager.py
@@ -239,6 +239,20 @@ class TaskManager:
             _log.info('[Task] 请求停止任务: {}', self._current_task.task_id)
             return True
 
+    def wait_for_completion(self, timeout: float | None = None) -> bool:
+        """等待当前 worker 实际退出。
+
+        ``stop_task()`` 只发出协作式停止信号。生命周期调用方必须使用本方法
+        确认 worker 已结束后，才能释放或替换其持有的 ``GameContext``。
+        """
+        thread = self._executor_thread
+        if thread is None:
+            return True
+        if thread is threading.current_thread():
+            return False
+        thread.join(timeout=timeout)
+        return not thread.is_alive()
+
     def update_progress(
         self,
         current_round: int | None = None,

--- a/testing/server/__init__.py
+++ b/testing/server/__init__.py
@@ -1,0 +1,1 @@
+"""Server integration tests."""

--- a/testing/server/test_system_routes.py
+++ b/testing/server/test_system_routes.py
@@ -1,0 +1,59 @@
+"""System lifecycle route tests."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from autowsgr.server import main as server_main
+from autowsgr.server.routes import system
+
+
+if TYPE_CHECKING:
+    import pytest
+
+
+class _RunningTaskManager:
+    is_running = True
+
+    def __init__(self, *, completed: bool) -> None:
+        self.completed = completed
+        self.stop_requested = False
+
+    def stop_task(self) -> bool:
+        self.stop_requested = True
+        return True
+
+    def wait_for_completion(self, timeout: float | None = None) -> bool:
+        assert timeout is not None
+        return self.completed
+
+
+def test_system_stop_keeps_context_when_worker_does_not_finish(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stop timeout must not release a context still used by the worker."""
+    ctx = object()
+    manager = _RunningTaskManager(completed=False)
+    monkeypatch.setattr(server_main, '_ctx', ctx)
+    monkeypatch.setattr(system, 'task_manager', manager)
+
+    response = asyncio.run(system.system_stop())
+
+    assert manager.stop_requested is True
+    assert response.success is False
+    assert server_main._ctx is ctx
+
+
+def test_system_stop_releases_context_after_worker_finishes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The global context is released only after worker termination is confirmed."""
+    manager = _RunningTaskManager(completed=True)
+    monkeypatch.setattr(server_main, '_ctx', object())
+    monkeypatch.setattr(system, 'task_manager', manager)
+
+    response = asyncio.run(system.system_stop())
+
+    assert response.success is True
+    assert server_main._ctx is None

--- a/testing/server/test_task_manager.py
+++ b/testing/server/test_task_manager.py
@@ -1,0 +1,78 @@
+"""Task manager outcome contract tests."""
+
+from __future__ import annotations
+
+import time
+
+from autowsgr.server.task_manager import TaskManager, TaskOutcome, TaskStatus
+
+
+def _wait_until_finished(manager: TaskManager, timeout: float = 1.0) -> None:
+    deadline = time.monotonic() + timeout
+    while manager.is_running and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert manager.is_running is False
+
+
+def test_failed_round_marks_task_failed_and_preserves_details() -> None:
+    """A handled round failure must not be broadcast as task success."""
+    manager = TaskManager()
+    failed_round = {'round': 1, 'success': False, 'error': 'fleet change failed'}
+
+    manager.start_task(
+        task_type='normal_fight',
+        total_rounds=1,
+        executor=lambda _task: TaskOutcome.from_results([failed_round]),
+    )
+    _wait_until_finished(manager)
+
+    assert manager.current_task is not None
+    assert manager.current_task.status is TaskStatus.FAILED
+    assert manager.current_task.results == [failed_round]
+    assert manager.current_task.error == 'fleet change failed'
+    assert manager.get_status()['result'] == {
+        'total_runs': 1,
+        'success_runs': 0,
+        'details': [failed_round],
+    }
+
+
+def test_successful_rounds_mark_task_completed() -> None:
+    """A task completes only when every returned round succeeded."""
+    manager = TaskManager()
+    results = [
+        {'round': 1, 'success': True},
+        {'round': 2, 'success': True},
+    ]
+
+    manager.start_task(
+        task_type='normal_fight',
+        total_rounds=2,
+        executor=lambda _task: TaskOutcome.from_results(results),
+    )
+    _wait_until_finished(manager)
+
+    assert manager.current_task is not None
+    assert manager.current_task.status is TaskStatus.COMPLETED
+    assert manager.current_task.error is None
+    assert manager.get_status()['result'] == {
+        'total_runs': 2,
+        'success_runs': 2,
+        'details': results,
+    }
+
+
+def test_empty_outcome_is_not_synthetic_success() -> None:
+    """Returning no rounds without a stop request is an execution failure."""
+    manager = TaskManager()
+
+    manager.start_task(
+        task_type='normal_fight',
+        total_rounds=1,
+        executor=lambda _task: TaskOutcome.from_results([]),
+    )
+    _wait_until_finished(manager)
+
+    assert manager.current_task is not None
+    assert manager.current_task.status is TaskStatus.FAILED
+    assert manager.current_task.error == '任务未执行任何轮次'

--- a/testing/server/test_task_manager.py
+++ b/testing/server/test_task_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 import time
 
 from autowsgr.server.task_manager import TaskManager, TaskOutcome, TaskStatus
@@ -76,3 +77,27 @@ def test_empty_outcome_is_not_synthetic_success() -> None:
     assert manager.current_task is not None
     assert manager.current_task.status is TaskStatus.FAILED
     assert manager.current_task.error == '任务未执行任何轮次'
+
+
+def test_wait_for_completion_does_not_acknowledge_a_running_worker() -> None:
+    """Shutdown callers can distinguish a stop request from actual worker termination."""
+    manager = TaskManager()
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+
+    def executor(_task: object) -> TaskOutcome:
+        worker_started.set()
+        release_worker.wait(timeout=1)
+        return TaskOutcome.from_results([{'round': 1, 'success': True}])
+
+    manager.start_task(task_type='normal_fight', total_rounds=1, executor=executor)
+    assert worker_started.wait(timeout=1)
+    assert manager.stop_task() is True
+
+    assert manager.wait_for_completion(timeout=0.01) is False
+    assert manager.current_task is not None
+    assert manager.current_task.status is TaskStatus.RUNNING
+
+    release_worker.set()
+    assert manager.wait_for_completion(timeout=1) is True
+    assert manager.current_task.status is TaskStatus.STOPPED

--- a/testing/server/test_task_manager.py
+++ b/testing/server/test_task_manager.py
@@ -79,6 +79,14 @@ def test_empty_outcome_is_not_synthetic_success() -> None:
     assert manager.current_task.error == '任务未执行任何轮次'
 
 
+def test_stop_event_is_exposed_as_read_only_execution_token() -> None:
+    """Callers can inject cancellation without reaching into private manager state."""
+    manager = TaskManager()
+
+    assert manager.stop_event is manager.stop_event
+    assert manager.stop_event.is_set() is False
+
+
 def test_wait_for_completion_does_not_acknowledge_a_running_worker() -> None:
     """Shutdown callers can distinguish a stop request from actual worker termination."""
     manager = TaskManager()


### PR DESCRIPTION
## Summary

Make the server task result and shutdown lifecycle explicit instead of inferring business success from whether an executor raised.

- add `TaskOutcome` as the executor result contract
- preserve all round details and mark any handled round failure as task failure
- treat zero executed rounds as failure instead of synthetic success
- make `/api/system/stop` wait for the task worker to actually exit before releasing `GameContext`
- keep the context active and return an error when cooperative shutdown times out
- expose the cancellation event through the read-only `TaskManager.stop_event` property

## Motivation

Previously, route executors could return after a handled round failure without raising, and `TaskManager` would report the task as completed. System shutdown also released the global context immediately after setting the cancellation event, even though the worker could still be using that context.

The new contract separates three facts:

1. cancellation was requested
2. the worker actually exited
3. the task's business result succeeded or failed

## Testing

Validated on the branch before publication:

- `548 passed`
- `ruff check .`
- Ruff format check for changed files
- full pre-commit hooks
- codespell

Focused regression coverage includes:

- failed round details are retained and task status is `FAILED`
- successful rounds complete normally
- empty outcomes are not reported as success
- shutdown timeout preserves `GameContext`
- completed worker shutdown releases `GameContext`
- cancellation token is accessed through the public property

## Scope

This PR intentionally does not address:

- route-level start/stop concurrency serialization
- global device-operation mutual exclusion
- scheduler batch-result normalization
- OCR, fleet rules, or `autowsgr_native` migration