### PR TITLE
chore(ci): restore lint and cross-platform test baseline

### DIFF
--- a/autowsgr/constants/shipnames.py
+++ b/autowsgr/constants/shipnames.py
@@ -42,9 +42,7 @@ SHIPNAME_GROUPS: dict[str, list[str]] = {
 }
 _EXTRA_SHIPNAMES: list[str] = []
 _SHIPNAME_TO_GROUP: dict[str, str] = {
-    name: group_id
-    for group_id, names in SHIPNAME_GROUPS.items()
-    for name in names
+    name: group_id for group_id, names in SHIPNAME_GROUPS.items() for name in names
 }
 SHIPNAMES: list[str] = process_dict(SHIPNAME_GROUPS)
 
@@ -107,10 +105,7 @@ def set_ship_name_aliases(aliases: Mapping[str, str]) -> None:
     """重置用户自定义名，并追加到目标标准舰名所在的舰船组。"""
     SHIPNAME_GROUPS.clear()
     SHIPNAME_GROUPS.update(
-        {
-            group_id: list(names)
-            for group_id, names in _BASE_SHIPNAME_GROUPS.items()
-        },
+        {group_id: list(names) for group_id, names in _BASE_SHIPNAME_GROUPS.items()},
     )
     _rebuild_shipnames()
 
@@ -125,11 +120,7 @@ def _rebuild_shipnames() -> None:
     """原地刷新扁平舰名列表和舰名到分组的索引。"""
     _SHIPNAME_TO_GROUP.clear()
     _SHIPNAME_TO_GROUP.update(
-        {
-            name: group_id
-            for group_id, names in SHIPNAME_GROUPS.items()
-            for name in names
-        },
+        {name: group_id for group_id, names in SHIPNAME_GROUPS.items() for name in names},
     )
     grouped_names = process_dict(SHIPNAME_GROUPS)
     SHIPNAMES[:] = list(dict.fromkeys([*_EXTRA_SHIPNAMES, *grouped_names]))

--- a/autowsgr/infra/config.py
+++ b/autowsgr/infra/config.py
@@ -35,6 +35,7 @@ _log = get_logger('infra')
 OPERATION_DELAY_MIN: float = 0.0
 OPERATION_DELAY_MAX: float = 0.0
 
+
 def operation_delay() -> float:
     """本次 UI 操作后的随机延迟秒数。
 
@@ -47,6 +48,7 @@ def operation_delay() -> float:
         min(OPERATION_DELAY_MIN, OPERATION_DELAY_MAX),
         max(OPERATION_DELAY_MIN, OPERATION_DELAY_MAX),
     )
+
 
 # ── 基础运行配置 ──
 
@@ -125,6 +127,7 @@ class OCRConfig(BaseModel):
             corrections[source] = target
         return corrections
 
+
 class LogConfig(BaseModel):
     """日志配置。"""
 
@@ -199,6 +202,7 @@ class LogConfig(BaseModel):
         merged.update(self.channels)
         return merged
 
+
 # ── 自动化任务配置 ──
 class NormalFightTaskConfig(BaseModel):
     """单个常规战任务配置。
@@ -207,6 +211,7 @@ class NormalFightTaskConfig(BaseModel):
     (经 :func:`_parse_normal_fight_tasks` 解析), 也支持纯字符串 (仅 plan 名)
     或完整字典。
     """
+
     model_config = {'frozen': True}
 
     name: str
@@ -220,6 +225,7 @@ class NormalFightTaskConfig(BaseModel):
        ``stop_max_loot`` / ``quick_repair_limit`` 任一上限时, 常规战会持续
        产出任务、永远抢占浴室修理 (优先级更低), 致浴室修理永不执行。
     """
+
 
 class DailyAutomationConfig(BaseModel):
     """日常自动化设置。"""
@@ -309,6 +315,7 @@ class DailyAutomationConfig(BaseModel):
                 raise TypeError(f'无法识别的常规战任务条目: {item!r}')
         return result
 
+
 class DecisiveConfig(BaseModel):
     """决战自动化配置。"""
 
@@ -347,6 +354,7 @@ class DecisiveConfig(BaseModel):
         if not 1 <= v <= 6:
             raise ValueError('决战章节必须为 1-6 之间的整数')
         return v
+
 
 # ── 顶层用户配置 ──
 
@@ -490,6 +498,7 @@ class UserConfig(BaseModel):
             )
         return cls.model_validate(data)
 
+
 # ── 战斗相关配置 ──
 class NodeConfig(BaseModel):
     """单个地图节点的战斗配置。"""
@@ -527,6 +536,7 @@ class NodeConfig(BaseModel):
     proceed_stop: RepairMode | list[RepairMode] = RepairMode.severe_damage
     """达到指定破损状态时停止前进"""
 
+
 class FightConfig(BaseModel):
     """出征配置（通用）。"""
 
@@ -555,10 +565,12 @@ class FightConfig(BaseModel):
             object.__setattr__(self, 'repair_mode', modes)
         return self
 
+
 class BattleConfig(FightConfig):
     """战役配置。"""
 
     repair_mode: RepairMode | list[RepairMode] = RepairMode.moderate_damage
+
 
 class ExerciseConfig(FightConfig):
     """演习配置。"""
@@ -572,9 +584,11 @@ class ExerciseConfig(FightConfig):
     max_refresh_times: int = 2
     """最大刷新次数"""
 
+
 # ── ConfigManager ──
 # 默认配置文件名（当前目录下）
 _DEFAULT_CONFIG_FILENAME = 'usersettings.yaml'
+
 
 class ConfigManager:
     """配置管理器 — 提供加载入口。"""

--- a/autowsgr/ui/battle/fleet_change/_change.py
+++ b/autowsgr/ui/battle/fleet_change/_change.py
@@ -355,9 +355,7 @@ class FleetChangeMixin(FleetDetectMixin):
         }
         # available 保留当前舰队中尚未占用的候选。
         available = [
-            candidate
-            for candidate in candidates
-            if cls._ship_identity(candidate) not in occupied
+            candidate for candidate in candidates if cls._ship_identity(candidate) not in occupied
         ]
 
         if len(available) == 0:
@@ -442,13 +440,15 @@ class FleetChangeMixin(FleetDetectMixin):
         if selector is None:
             return cls._ship_identity(current_name) == cls._ship_identity(target)
         candidate_identities = {
-            cls._ship_identity(candidate)
-            for candidate in cls._slot_candidates(target, selector)
+            cls._ship_identity(candidate) for candidate in cls._slot_candidates(target, selector)
         }
-        return cls._matches_search_name(
-            current_name,
-            selector.get('search_name'),
-        ) and cls._ship_identity(current_name) in candidate_identities
+        return (
+            cls._matches_search_name(
+                current_name,
+                selector.get('search_name'),
+            )
+            and cls._ship_identity(current_name) in candidate_identities
+        )
 
     # 验证当前六个槽位是否完整满足目标，并拒绝队内同名舰。
     @classmethod

--- a/autowsgr/ui/battle/fleet_change/_detect.py
+++ b/autowsgr/ui/battle/fleet_change/_detect.py
@@ -101,9 +101,7 @@ class FleetDetectMixin(BaseBattlePreparation):
         )
         expected_slots = (
             [
-                normalize_ship_name_suffix(name)
-                if isinstance(name, str) and name.strip()
-                else None
+                normalize_ship_name_suffix(name) if isinstance(name, str) and name.strip() else None
                 for name in list(expected_names)[:6]
             ]
             if expected_names is not None

--- a/autowsgr/vision/ocr.py
+++ b/autowsgr/vision/ocr.py
@@ -456,9 +456,7 @@ def _fuzzy_match(text: str, candidates: list[str], threshold: int = 3) -> str | 
     best_dist = min(distance for _, distance in distances)
     nearest = list(
         dict.fromkeys(
-            resolve_ship_name_alias(name)
-            for name, distance in distances
-            if distance == best_dist
+            resolve_ship_name_alias(name) for name, distance in distances if distance == best_dist
         ),
     )
     best_name = nearest[0] if len(nearest) == 1 and best_dist <= effective_threshold else None

--- a/testing/infra/test_config.py
+++ b/testing/infra/test_config.py
@@ -118,7 +118,15 @@ class TestDecisiveConfig:
 
 class TestUserConfig:
     def test_unused_bathroom_feature_count_is_removed(self):
-        assert not hasattr(UserConfig(), 'bathroom_feature_count')
+        config = UserConfig(
+            emulator=EmulatorConfig(
+                serial='127.0.0.1:5555',
+                path='/tmp/emulator',
+            ),
+            os_type=OSType.linux,
+        )
+
+        assert not hasattr(config, 'bathroom_feature_count')
 
     def test_from_yaml(self, tmp_yaml: Callable[[str, str], Path]):
         content = """\


### PR DESCRIPTION
## Summary

Restore the currently red `main` CI baseline without weakening CI rules.

- apply the repository's pinned Ruff formatter to the five files that fail `pre-commit --all-files`
- make the removed `bathroom_feature_count` assertion construct a platform-valid `UserConfig`
- preserve the production requirement that Linux/WSL users explicitly configure emulator path and serial

## Root cause

`main@80aaca5` currently fails both required workflows:

- Lint: `ruff-format` reformats five existing files
- Pytest on Ubuntu: `UserConfig()` enters the Linux/WSL validation path before the test can check the removed field

The test is intended to verify field removal, not platform autodetection, so it now supplies an explicit valid emulator configuration.

## Validation

Local substantive lint checks:

- `uv run pre-commit run ruff-check --all-files`
- `uv run pre-commit run ruff-format --all-files`
- `uv run pre-commit run codespell --all-files`

All passed.

Full local test command matching CI options:

```text
uv run pytest -n auto --cov=autowsgr --cov-report=xml --cov-report=term-missing --junitxml=junit.xml
```

Result:

```text
541 passed
```

The Windows checkout represents repository symlinks as link-target files, so the all-files EOF hook proposes newline changes to `CLAUDE.md` and `.claude/skills`. Those false platform-specific changes were restored and are not included. Ubuntu CI preserves the symlinks and already passes that hook.

## Scope

No production behavior is changed except mechanical formatting. CI remains strict and continues to run `pre-commit --all-files` and the full Linux test suite.

This PR should merge before #524 so its checks can be rerun against a green baseline.