### PR TITLE
fix(server): serialize lifecycle transitions

### DIFF
--- a/autowsgr/server/main.py
+++ b/autowsgr/server/main.py
@@ -40,6 +40,9 @@ _log = get_logger('server')
 # GameContext 全局引用 (启动后设置)
 _ctx: Any = None
 
+# 序列化系统上下文的发布、任务准入和回收。
+lifecycle_lock = asyncio.Lock()
+
 
 def get_context() -> Any:
     """获取全局 GameContext。"""

--- a/autowsgr/server/routes/system.py
+++ b/autowsgr/server/routes/system.py
@@ -29,32 +29,35 @@ class SystemStartRequest(BaseModel):
 @router.post('/start', response_model=ApiResponse)
 async def system_start(request: SystemStartRequest) -> ApiResponse:
     """启动系统 (连接模拟器、启动游戏)。"""
-    if _main._ctx is not None:
-        return ApiResponse(success=True, message='系统已启动')
+    async with _main.lifecycle_lock:
+        if _main._ctx is not None:
+            return ApiResponse(success=True, message='系统已启动')
 
-    try:
-        from autowsgr.scheduler import launch
+        try:
+            from autowsgr.scheduler import launch
 
-        config_path = request.config_path or 'usersettings.yaml'
-        _log.info('[System] 正在启动, 配置: {}', config_path)
-        _main._ctx = launch(config_path)
-        _log.info('[System] 启动成功')
+            config_path = request.config_path or 'usersettings.yaml'
+            _log.info('[System] 正在启动, 配置: {}', config_path)
+            _main._ctx = launch(config_path)
+            _log.info('[System] 启动成功')
 
-        return ApiResponse(success=True, message='系统启动成功')
+            return ApiResponse(success=True, message='系统启动成功')
 
-    except Exception as e:
-        _log.error('[System] 启动失败: {}', e)
-        return ApiResponse(success=False, error=str(e))
+        except Exception as e:
+            _log.error('[System] 启动失败: {}', e)
+            return ApiResponse(success=False, error=str(e))
 
 
 @router.post('/stop', response_model=ApiResponse)
 async def system_stop() -> ApiResponse:
     """停止系统。"""
-    if _main._ctx is None:
-        return ApiResponse(success=True, message='系统未运行')
+    async with _main.lifecycle_lock:
+        if _main._ctx is None:
+            return ApiResponse(success=True, message='系统未运行')
 
-    if task_manager.is_running:
-        task_manager.stop_task()
+        if task_manager.is_running:
+            task_manager.stop_task()
+
         completed = await asyncio.to_thread(
             task_manager.wait_for_completion,
             _TASK_STOP_TIMEOUT_SECONDS,
@@ -66,9 +69,9 @@ async def system_stop() -> ApiResponse:
                 error='任务未在超时前停止，系统上下文仍保持活动状态',
             )
 
-    _main._ctx = None
-    _log.info('[System] 系统已停止')
-    return ApiResponse(success=True, message='系统已停止')
+        _main._ctx = None
+        _log.info('[System] 系统已停止')
+        return ApiResponse(success=True, message='系统已停止')
 
 
 @router.get('/status', response_model=ApiResponse)

--- a/autowsgr/server/routes/task.py
+++ b/autowsgr/server/routes/task.py
@@ -19,7 +19,7 @@ from autowsgr.server.schemas import (
 from autowsgr.server.serializers import build_combat_plan, convert_combat_result
 from autowsgr.server.task_manager import TaskOutcome, task_manager
 
-from ..main import get_context
+from ..main import get_context, lifecycle_lock
 
 
 _log = get_logger('server')
@@ -36,28 +36,29 @@ TaskRequestUnion = Annotated[
 @router.post('/start', response_model=ApiResponse)
 async def task_start(request: TaskRequestUnion) -> ApiResponse:  # type: ignore[arg-type]
     """启动任务 (异步执行，立即返回)。"""
-    if task_manager.is_running:
-        raise HTTPException(status_code=409, detail='已有任务正在运行')
+    async with lifecycle_lock:
+        if task_manager.is_running:
+            raise HTTPException(status_code=409, detail='已有任务正在运行')
 
-    try:
-        ctx = get_context()
-    except RuntimeError as e:
-        raise HTTPException(status_code=503, detail=str(e)) from e
+        try:
+            ctx = get_context()
+        except RuntimeError as e:
+            raise HTTPException(status_code=503, detail=str(e)) from e
 
-    ctx.stop_event = task_manager.stop_event
+        ctx.stop_event = task_manager.stop_event
 
-    if isinstance(request, NormalFightRequest):
-        return await _start_normal_fight(ctx, request)
-    elif isinstance(request, EventFightRequest):
-        return await _start_event_fight(ctx, request)
-    elif isinstance(request, CampaignRequest):
-        return await _start_campaign(ctx, request)
-    elif isinstance(request, ExerciseRequest):
-        return await _start_exercise(ctx, request)
-    elif isinstance(request, DecisiveRequest):
-        return await _start_decisive(ctx, request)
-    else:
-        raise HTTPException(status_code=400, detail='未知的任务类型')
+        if isinstance(request, NormalFightRequest):
+            return await _start_normal_fight(ctx, request)
+        elif isinstance(request, EventFightRequest):
+            return await _start_event_fight(ctx, request)
+        elif isinstance(request, CampaignRequest):
+            return await _start_campaign(ctx, request)
+        elif isinstance(request, ExerciseRequest):
+            return await _start_exercise(ctx, request)
+        elif isinstance(request, DecisiveRequest):
+            return await _start_decisive(ctx, request)
+        else:
+            raise HTTPException(status_code=400, detail='未知的任务类型')
 
 
 @router.post('/stop', response_model=ApiResponse)

--- a/testing/server/test_system_routes.py
+++ b/testing/server/test_system_routes.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING
+import threading
+
+import pytest
+from fastapi import HTTPException
 
 from autowsgr.server import main as server_main
-from autowsgr.server.routes import system
-
-
-if TYPE_CHECKING:
-    import pytest
+from autowsgr.server.routes import system, task
+from autowsgr.server.schemas import ExerciseRequest
 
 
 class _RunningTaskManager:
@@ -27,6 +27,36 @@ class _RunningTaskManager:
     def wait_for_completion(self, timeout: float | None = None) -> bool:
         assert timeout is not None
         return self.completed
+
+
+class _TerminalTaskManager:
+    is_running = False
+
+    def __init__(self, *, completed: bool) -> None:
+        self.completed = completed
+        self.wait_called = False
+
+    def wait_for_completion(self, timeout: float | None = None) -> bool:
+        assert timeout is not None
+        self.wait_called = True
+        return self.completed
+
+
+class _StoppingTaskManager:
+    def __init__(self) -> None:
+        self.is_running = True
+        self.stop_event = threading.Event()
+        self.worker_terminal = threading.Event()
+        self.release_wait = threading.Event()
+
+    def stop_task(self) -> bool:
+        return True
+
+    def wait_for_completion(self, timeout: float | None = None) -> bool:
+        assert timeout is not None
+        self.is_running = False
+        self.worker_terminal.set()
+        return self.release_wait.wait(timeout=timeout)
 
 
 def test_system_stop_keeps_context_when_worker_does_not_finish(
@@ -57,3 +87,64 @@ def test_system_stop_releases_context_after_worker_finishes(
 
     assert response.success is True
     assert server_main._ctx is None
+
+
+def test_system_stop_keeps_context_until_terminal_worker_exits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A terminal task status must not be mistaken for worker termination."""
+    ctx = object()
+    manager = _TerminalTaskManager(completed=False)
+    monkeypatch.setattr(server_main, '_ctx', ctx)
+    monkeypatch.setattr(system, 'task_manager', manager)
+
+    response = asyncio.run(system.system_stop())
+
+    assert manager.wait_called is True
+    assert response.success is False
+    assert server_main._ctx is ctx
+
+
+def test_task_start_cannot_reuse_context_being_stopped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A new task cannot claim a context already owned by system shutdown."""
+    manager = _StoppingTaskManager()
+    ctx = type('Context', (), {'stop_event': None})()
+    started_contexts: list[object] = []
+    monkeypatch.setattr(server_main, '_ctx', ctx)
+    monkeypatch.setattr(system, 'task_manager', manager)
+    monkeypatch.setattr(task, 'task_manager', manager)
+
+    async def fake_start_exercise(
+        received_ctx: object,
+        _request: ExerciseRequest,
+    ) -> object:
+        started_contexts.append(received_ctx)
+        return object()
+
+    monkeypatch.setattr(task, '_start_exercise', fake_start_exercise)
+
+    async def run_race() -> None:
+        stop_call = asyncio.create_task(system.system_stop())
+        assert await asyncio.to_thread(manager.worker_terminal.wait, 1)
+
+        start_call = asyncio.create_task(task.task_start(ExerciseRequest()))
+        await asyncio.sleep(0)
+
+        assert start_call.done() is False
+        assert started_contexts == []
+
+        manager.release_wait.set()
+        stop_response = await stop_call
+        assert stop_response.success is True
+
+        with pytest.raises(HTTPException) as exc_info:
+            await start_call
+
+        assert exc_info.value.status_code == 503
+
+    asyncio.run(run_race())
+
+    assert server_main._ctx is None
+    assert started_contexts == []

--- a/testing/server/test_system_routes.py
+++ b/testing/server/test_system_routes.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 import threading
+import types
 
 import pytest
 from fastapi import HTTPException
@@ -57,6 +59,63 @@ class _StoppingTaskManager:
         self.is_running = False
         self.worker_terminal.set()
         return self.release_wait.wait(timeout=timeout)
+
+
+def test_system_start_publishes_launched_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful start publishes the launched context exactly once."""
+    launched_context = object()
+    launch_calls: list[str] = []
+    scheduler_module = types.ModuleType('autowsgr.scheduler')
+
+    def launch(config_path: str) -> object:
+        launch_calls.append(config_path)
+        return launched_context
+
+    scheduler_module.launch = launch  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, 'autowsgr.scheduler', scheduler_module)
+    monkeypatch.setattr(server_main, '_ctx', None)
+
+    response = asyncio.run(system.system_start(system.SystemStartRequest(config_path='test.yaml')))
+
+    assert response.success is True
+    assert launch_calls == ['test.yaml']
+    assert server_main._ctx is launched_context
+
+
+def test_system_start_is_idempotent_when_context_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An already published context is not launched again."""
+    ctx = object()
+    monkeypatch.setattr(server_main, '_ctx', ctx)
+
+    response = asyncio.run(system.system_start(system.SystemStartRequest()))
+
+    assert response.success is True
+    assert response.message == '系统已启动'
+    assert server_main._ctx is ctx
+
+
+def test_system_start_reports_launch_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Launch errors leave the global context unpublished."""
+    scheduler_module = types.ModuleType('autowsgr.scheduler')
+
+    def launch(_config_path: str) -> object:
+        raise RuntimeError('launch failed')
+
+    scheduler_module.launch = launch  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, 'autowsgr.scheduler', scheduler_module)
+    monkeypatch.setattr(server_main, '_ctx', None)
+
+    response = asyncio.run(system.system_start(system.SystemStartRequest()))
+
+    assert response.success is False
+    assert response.error == 'launch failed'
+    assert server_main._ctx is None
 
 
 def test_system_stop_keeps_context_when_worker_does_not_finish(

--- a/testing/server/test_task_routes.py
+++ b/testing/server/test_task_routes.py
@@ -1,0 +1,82 @@
+"""Task route admission tests."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+
+import pytest
+from fastapi import HTTPException
+
+from autowsgr.server import main as server_main
+from autowsgr.server.routes import task
+from autowsgr.server.schemas import (
+    CampaignRequest,
+    DecisiveRequest,
+    EventFightRequest,
+    ExerciseRequest,
+    NormalFightRequest,
+)
+
+
+@dataclass
+class _TaskManager:
+    is_running: bool = False
+    stop_event: object = field(default_factory=object)
+
+
+def test_task_start_rejects_concurrent_task(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Task admission rejects a second running task under the lifecycle lock."""
+    monkeypatch.setattr(task, 'task_manager', _TaskManager(is_running=True))
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(task.task_start(ExerciseRequest()))
+
+    assert exc_info.value.status_code == 409
+
+
+def test_task_start_requires_system_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Task admission fails after system shutdown removed the context."""
+    monkeypatch.setattr(task, 'task_manager', _TaskManager())
+    monkeypatch.setattr(server_main, '_ctx', None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(task.task_start(ExerciseRequest()))
+
+    assert exc_info.value.status_code == 503
+
+
+@pytest.mark.parametrize(
+    ('task_request', 'helper_name'),
+    [
+        (NormalFightRequest(plan_id='plan.yaml'), '_start_normal_fight'),
+        (EventFightRequest(plan_id='event.yaml'), '_start_event_fight'),
+        (CampaignRequest(campaign_name='困难航母'), '_start_campaign'),
+        (ExerciseRequest(), '_start_exercise'),
+        (DecisiveRequest(), '_start_decisive'),
+    ],
+)
+def test_task_start_dispatches_request_with_shared_context(
+    monkeypatch: pytest.MonkeyPatch,
+    task_request: object,
+    helper_name: str,
+) -> None:
+    """Each supported request is admitted with the current context and stop token."""
+    manager = _TaskManager()
+    ctx = type('Context', (), {'stop_event': None})()
+    calls: list[tuple[object, object]] = []
+    response = object()
+
+    async def start_helper(received_ctx: object, received_request: object) -> object:
+        calls.append((received_ctx, received_request))
+        return response
+
+    monkeypatch.setattr(task, 'task_manager', manager)
+    monkeypatch.setattr(server_main, '_ctx', ctx)
+    monkeypatch.setattr(task, helper_name, start_helper)
+
+    result = asyncio.run(task.task_start(task_request))  # type: ignore[arg-type]
+
+    assert result is response
+    assert calls == [(ctx, task_request)]
+    assert ctx.stop_event is manager.stop_event


### PR DESCRIPTION
## Summary
- serialize system start, system stop, and task admission around the shared game context
- wait for worker termination even after task status becomes terminal
- reject task starts that race with context shutdown instead of reusing a retiring context

## Verification
- uv run --frozen pytest testing/server/test_task_manager.py testing/server/test_system_routes.py -q (9 passed)
- uv run --frozen pytest -n auto --cov=autowsgr --cov-report=xml --cov-report=term-missing --junitxml=junit.xml (550 passed)
- uv run --frozen pre-commit run ruff-check --all-files
- uv run --frozen pre-commit run ruff-format --all-files
- uv run --frozen pre-commit run codespell --all-files

Full pre-commit --all-files passes all substantive hooks locally. On Windows, end-of-file-fixer rewrites the repository's Git symlink entries (CLAUDE.md and .claude/skills); those checkout artifacts were restored unchanged. Ubuntu CI remains the authoritative full pre-commit result.