### PR TITLE
fix(scheduler): preserve batch fight results

### DIFF
--- a/autowsgr/scheduler/scheduler.py
+++ b/autowsgr/scheduler/scheduler.py
@@ -60,12 +60,10 @@ class FightRunnerProtocol(Protocol):
 
 
 class BatchRunnerAdapter:
-    """将 ``run() → list[CombatResult]`` 的 runner 适配为单次协议。
+    """将 runner 输出规范化为完整的 ``list[CombatResult]``。
 
     适用于 :class:`CampaignRunner` (内部自带循环，每次 ``run()`` 已执行多场)
     和 :class:`ExerciseRunner`。
-
-    每次 ``.run()`` 返回最后一场结果；若列表为空，返回默认成功。
     """
 
     def __init__(self, inner: object) -> None:
@@ -73,17 +71,11 @@ class BatchRunnerAdapter:
             raise TypeError(f'{type(inner).__name__} 没有 run() 方法')
         self._inner = inner
 
-    def run(self) -> CombatResult:
+    def run(self) -> list[CombatResult]:
         results = self._inner.run()  # type: ignore[union-attr]
         if isinstance(results, list):
-            return (
-                results[-1]
-                if results
-                else CombatResult(
-                    flag=ConditionFlag.OPERATION_SUCCESS,
-                )
-            )
-        return results  # type: ignore[return-value]
+            return results
+        return [results]  # type: ignore[list-item]
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -213,8 +205,8 @@ class TaskScheduler:
 
     def _run_task(self, task: FightTask) -> None:
         """执行单个任务的全部轮次。"""
-        # 统一用 BatchRunnerAdapter 包装: 对 run()→list[CombatResult] 取最后一场,
-        # 对 run()→单个 CombatResult 直接 passthrough, 兼容两类 runner
+        # 统一用 BatchRunnerAdapter 包装: 完整保留 run()→list[CombatResult],
+        # 对 run()→单个 CombatResult 规范化为单元素列表, 兼容两类 runner
         # (CampaignRunner / ExerciseRunner 返回 list, 其余返回单个)。
         # 不能靠 isinstance(FightRunnerProtocol) 判断: @runtime_checkable 不检查
         # 返回类型, CampaignRunner 有 run() 方法即被误判满足协议而跳过适配
@@ -239,7 +231,7 @@ class TaskScheduler:
                 self._maybe_collect_expedition()
 
                 try:
-                    result = runner.run()
+                    results = runner.run()
                 except Exception as exc:
                     # 子任务异常: 结束本子任务, 不崩溃主循环。ACTION_FAILED 不属
                     # 于任何触发器的成功/耗尽标志, 故 on_done 不会计入战斗次数、
@@ -250,32 +242,37 @@ class TaskScheduler:
                         j + 1,
                         exc,
                     )
-                    result = CombatResult(flag=ConditionFlag.ACTION_FAILED)
+                    results = [CombatResult(flag=ConditionFlag.ACTION_FAILED)]
 
-                task.results.append(result)
+                if not results:
+                    _log.error('[Scheduler] {} 第 {} 次未执行任何战斗', task.name, j + 1)
+                    results = [CombatResult(flag=ConditionFlag.ACTION_FAILED)]
+
+                task.results.extend(results)
                 task.completed += 1
 
                 # 通知触发器更新状态 (auto_daily 触发器调度用)
-                if task.on_done is not None:
-                    try:
-                        task.on_done(result)
-                    except Exception as exc:
-                        _log.opt(exception=True).warning(
-                            '[Scheduler] {} on_done 回调异常: {}',
-                            task.name,
-                            exc,
-                        )
+                for result in results:
+                    if task.on_done is not None:
+                        try:
+                            task.on_done(result)
+                        except Exception as exc:
+                            _log.opt(exception=True).warning(
+                                '[Scheduler] {} on_done 回调异常: {}',
+                                task.name,
+                                exc,
+                            )
 
-                _log.info(
-                    '[Scheduler] {} [{}/{}] → {}',
-                    task.name,
-                    task.completed,
-                    task.times,
-                    result.flag.value if result.flag else 'N/A',
-                )
+                    _log.info(
+                        '[Scheduler] {} [{}/{}] → {}',
+                        task.name,
+                        task.completed,
+                        task.times,
+                        result.flag.value if result.flag else 'N/A',
+                    )
 
                 # 船坞满则停止当前任务
-                if result.flag == ConditionFlag.DOCK_FULL:
+                if any(result.flag == ConditionFlag.DOCK_FULL for result in results):
                     _log.warning(
                         '[Scheduler] {} 船坞已满, 跳过剩余 {} 次',
                         task.name,
@@ -493,13 +490,14 @@ class TaskScheduler:
 
         for task in self._tasks:
             success = sum(1 for r in task.results if r.flag == ConditionFlag.OPERATION_SUCCESS)
-            total_fights += task.completed
+            total_fights += len(task.results)
             total_success += success
             _log.info(
-                '[Scheduler]   {} : {}/{} 完成, {} 成功',
+                '[Scheduler]   {} : {}/{} 次执行, {} 场结果, {} 成功',
                 task.name,
                 task.completed,
                 task.times,
+                len(task.results),
                 success,
             )
 

--- a/testing/ops/test_scheduler_unit.py
+++ b/testing/ops/test_scheduler_unit.py
@@ -44,20 +44,19 @@ class _SingleRunner:
 # ── BatchRunnerAdapter 行为 ──
 
 
-def test_batch_adapter_list_takes_last():
+def test_batch_adapter_preserves_all_results():
     r1 = CombatResult(flag=ConditionFlag.OPERATION_SUCCESS)
     r2 = CombatResult(flag=ConditionFlag.BATTLE_TIMES_EXCEED)
-    assert BatchRunnerAdapter(_ListRunner([r1, r2])).run() is r2
+    assert BatchRunnerAdapter(_ListRunner([r1, r2])).run() == [r1, r2]
 
 
 def test_batch_adapter_single_passthrough():
     r = CombatResult(flag=ConditionFlag.OPERATION_SUCCESS)
-    assert BatchRunnerAdapter(_SingleRunner(r)).run() is r
+    assert BatchRunnerAdapter(_SingleRunner(r)).run() == [r]
 
 
-def test_batch_adapter_empty_list_defaults_success():
-    out = BatchRunnerAdapter(_ListRunner([])).run()
-    assert out.flag == ConditionFlag.OPERATION_SUCCESS
+def test_batch_adapter_preserves_empty_batch():
+    assert BatchRunnerAdapter(_ListRunner([])).run() == []
 
 
 # ── _run_task 端到端 (list runner 不再崩溃) ──
@@ -72,28 +71,29 @@ class _FakeCtx:
 
 
 def test_run_task_handles_list_runner(monkeypatch: pytest.MonkeyPatch):
-    """返回 list 的 runner 经调度器后, on_done 收到单个 CombatResult (回归崩溃)。"""
+    """返回 list 的 runner 经调度器后保留并通知每个结果。"""
     ctx = _FakeCtx()
     sched = TaskScheduler(ctx, expedition_interval=0)  # type: ignore[arg-type]
     monkeypatch.setattr(sched, '_maybe_collect_expedition', lambda: None)
 
     received: list[CombatResult] = []
-    result = CombatResult(flag=ConditionFlag.OPERATION_SUCCESS)
+    first = CombatResult(flag=ConditionFlag.OPERATION_SUCCESS)
+    second = CombatResult(flag=ConditionFlag.ACTION_FAILED)
     task = FightTask(
-        runner=_ListRunner([result]),
+        runner=_ListRunner([first, second]),
         times=1,
         on_done=received.append,
     )
 
     sched._run_task(task)  # 不应抛 AttributeError
 
-    assert received == [result]  # on_done 收到单个, 不是 list
-    assert task.results == [result]
+    assert received == [first, second]
+    assert task.results == [first, second]
     assert task.completed == 1
 
 
 def test_run_task_list_runner_exceed_flag(monkeypatch: pytest.MonkeyPatch):
-    """list runner 最后一场为 BATTLE_TIMES_EXCEED 时, 该 flag 正确传递给 on_done。"""
+    """list runner 的每场 flag 都按顺序传递给 on_done。"""
     ctx = _FakeCtx()
     sched = TaskScheduler(ctx, expedition_interval=0)  # type: ignore[arg-type]
     monkeypatch.setattr(sched, '_maybe_collect_expedition', lambda: None)
@@ -109,7 +109,7 @@ def test_run_task_list_runner_exceed_flag(monkeypatch: pytest.MonkeyPatch):
 
     sched._run_task(task)
 
-    assert seen == [ConditionFlag.BATTLE_TIMES_EXCEED]  # 取最后一场
+    assert seen == [ConditionFlag.OPERATION_SUCCESS, ConditionFlag.BATTLE_TIMES_EXCEED]
 
 
 def test_run_task_single_runner_still_works(monkeypatch: pytest.MonkeyPatch):
@@ -126,6 +126,70 @@ def test_run_task_single_runner_still_works(monkeypatch: pytest.MonkeyPatch):
 
     assert received == [result]
     assert task.results == [result]
+
+
+def test_run_task_empty_batch_is_explicit_failure(monkeypatch: pytest.MonkeyPatch):
+    """未执行任何战斗不能伪造成成功。"""
+    ctx = _FakeCtx()
+    sched = TaskScheduler(ctx, expedition_interval=0)  # type: ignore[arg-type]
+    monkeypatch.setattr(sched, '_maybe_collect_expedition', lambda: None)
+    received: list[CombatResult] = []
+    task = FightTask(runner=_ListRunner([]), times=1, on_done=received.append)
+
+    sched._run_task(task)
+
+    assert len(task.results) == 1
+    assert task.results[0].flag == ConditionFlag.ACTION_FAILED
+    assert received == task.results
+    assert task.completed == 1
+
+
+def test_run_task_dock_full_batch_stops_outer_repetition(monkeypatch: pytest.MonkeyPatch):
+    """批次内船坞满保留已返回结果，并阻止下一次 runner 调用。"""
+    ctx = _FakeCtx()
+    sched = TaskScheduler(ctx, expedition_interval=0)  # type: ignore[arg-type]
+    monkeypatch.setattr(sched, '_maybe_collect_expedition', lambda: None)
+    ok = CombatResult(flag=ConditionFlag.OPERATION_SUCCESS)
+    full = CombatResult(flag=ConditionFlag.DOCK_FULL)
+    runner = _ListRunner([ok, full])
+    calls = 0
+
+    def run() -> list[CombatResult]:
+        nonlocal calls
+        calls += 1
+        return [ok, full]
+
+    runner.run = run  # type: ignore[method-assign]
+    task = FightTask(runner=runner, times=3)
+
+    sched._run_task(task)
+
+    assert calls == 1
+    assert task.results == [ok, full]
+    assert task.completed == 1
+
+
+def test_run_task_concatenates_results_from_repeated_batches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """多次 runner 调用的批量结果按实际执行顺序完整保留。"""
+    ctx = _FakeCtx()
+    sched = TaskScheduler(ctx, expedition_interval=0)  # type: ignore[arg-type]
+    monkeypatch.setattr(sched, '_maybe_collect_expedition', lambda: None)
+    first = CombatResult(flag=ConditionFlag.OPERATION_SUCCESS)
+    second = CombatResult(flag=ConditionFlag.ACTION_FAILED)
+    third = CombatResult(flag=ConditionFlag.OPERATION_SUCCESS)
+    batches = iter([[first, second], [third]])
+    runner = _ListRunner([])
+    runner.run = lambda: next(batches)  # type: ignore[method-assign]
+    received: list[CombatResult] = []
+    task = FightTask(runner=runner, times=2, on_done=received.append)
+
+    sched._run_task(task)
+
+    assert task.results == [first, second, third]
+    assert received == task.results
+    assert task.completed == 2
 
 
 # ── 浴室修理优先级 (空闲修船: 所有战斗完成后才执行) ──


### PR DESCRIPTION
## Summary
- normalize scheduler runner output to a complete list[CombatResult] instead of selecting only the final result
- retain every batch result in execution order and notify on_done for each actual result
- represent an empty batch as ACTION_FAILED instead of synthetic success
- preserve all results when a batch reports DOCK_FULL, then stop further outer invocations
- report actual result count in scheduler summaries while retaining invocation progress separately

## Verification
- uv run --frozen pytest testing/ops/test_scheduler_unit.py testing/server/test_task_manager.py -q (35 passed)
- uv run --frozen pytest -n auto --cov=autowsgr --cov-report=xml --cov-report=term-missing --junitxml=junit.xml (584 passed)
- uv run --frozen pre-commit run ruff-check --all-files`n- uv run --frozen pre-commit run ruff-format --all-files`n- uv run --frozen pre-commit run codespell --all-files`n- local diff coverage against origin/main: 77% (target 53.17%)

This PR is limited to scheduler batch normalization and aggregation. It does not change server API outcome models, device ownership, native integration, or task cancellation semantics.