### PR TITLE
fix(server): preserve decisive task errors

### DIFF
--- a/autowsgr/server/routes/task.py
+++ b/autowsgr/server/routes/task.py
@@ -309,6 +309,7 @@ async def _start_decisive(ctx: Any, request: DecisiveRequest) -> ApiResponse:
 
         controller = DecisiveController(ctx, config)
         results: list[dict[str, Any]] = []
+        task_error: str | None = None
 
         try:
             for i in range(request.decisive_rounds):
@@ -318,7 +319,15 @@ async def _start_decisive(ctx: Any, request: DecisiveRequest) -> ApiResponse:
                 task_manager.update_progress(current_round=i + 1, current_node='决战')
                 _log.info('[Task] 决战第 {}/{} 轮', i + 1, request.decisive_rounds)
                 result = controller.run()
-                converted = {'round': i + 1, 'success': True, 'result': result.value}
+                is_error = result.value == 'error'
+                converted = {
+                    'round': i + 1,
+                    'success': not is_error,
+                    'result': result.value,
+                }
+                if is_error:
+                    task_error = '决战异常退出'
+                    converted['error'] = task_error
                 results.append(converted)
                 task_manager.add_result(converted)
 
@@ -328,7 +337,7 @@ async def _start_decisive(ctx: Any, request: DecisiveRequest) -> ApiResponse:
         except Exception as e:
             results.append({'round': len(results) + 1, 'success': False, 'error': str(e)})
 
-        return TaskOutcome.from_results(results)
+        return TaskOutcome.from_results(results, error=task_error)
 
     task_id = task_manager.start_task(
         task_type='decisive',

--- a/autowsgr/server/task_manager.py
+++ b/autowsgr/server/task_manager.py
@@ -49,8 +49,15 @@ class TaskOutcome:
     error: str | None = None
 
     @classmethod
-    def from_results(cls, results: list[dict[str, Any]]) -> TaskOutcome:
-        """根据逐轮结果构建任务结果。"""
+    def from_results(
+        cls,
+        results: list[dict[str, Any]],
+        error: str | None = None,
+    ) -> TaskOutcome:
+        """根据逐轮结果构建任务结果，优先保留显式任务级错误。"""
+        if error is not None:
+            return cls(results=results, success=False, error=error)
+
         failed_results = [result for result in results if not result.get('success', False)]
         if failed_results:
             error = next(

--- a/testing/server/test_task_manager.py
+++ b/testing/server/test_task_manager.py
@@ -85,6 +85,42 @@ def test_empty_outcome_is_not_synthetic_success() -> None:
     assert manager.current_task.error == '任务未执行任何轮次'
 
 
+def test_explicit_task_error_overrides_failed_round_error() -> None:
+    """An aggregate failure reason must outrank an incidental round error."""
+    failed_round = {'round': 1, 'success': False, 'error': 'low-level OCR failure'}
+
+    outcome = TaskOutcome.from_results(
+        [failed_round],
+        error='决战异常退出',
+    )
+
+    assert outcome.results == [failed_round]
+    assert outcome.success is False
+    assert outcome.error == '决战异常退出'
+
+
+def test_failed_round_error_is_inferred_without_explicit_task_error() -> None:
+    """Existing callers retain first-specific-round error inference."""
+    results = [
+        {'round': 1, 'success': False},
+        {'round': 2, 'success': False, 'error': 'fleet change failed'},
+    ]
+
+    outcome = TaskOutcome.from_results(results)
+
+    assert outcome.success is False
+    assert outcome.error == 'fleet change failed'
+
+
+def test_explicit_task_error_explains_empty_result_failure() -> None:
+    """An executor can explain why it terminated before producing a round."""
+    outcome = TaskOutcome.from_results([], error='决战初始化失败')
+
+    assert outcome.results == []
+    assert outcome.success is False
+    assert outcome.error == '决战初始化失败'
+
+
 def test_stop_event_is_exposed_as_read_only_execution_token() -> None:
     """Callers can inject cancellation without reaching into private manager state."""
     manager = TaskManager()

--- a/testing/server/test_task_routes.py
+++ b/testing/server/test_task_routes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from fastapi import HTTPException
@@ -20,10 +21,40 @@ from autowsgr.server.schemas import (
 )
 
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from autowsgr.server.task_manager import TaskOutcome
+
+
 @dataclass
 class _TaskManager:
     is_running: bool = False
     stop_event: object = field(default_factory=object)
+
+
+@dataclass
+class _ExecutingTaskManager:
+    outcome: TaskOutcome | None = None
+
+    def should_stop(self) -> bool:
+        return False
+
+    def update_progress(self, **_progress: object) -> None:
+        return None
+
+    def add_result(self, _result: dict[str, Any]) -> None:
+        return None
+
+    def start_task(
+        self,
+        task_type: str,
+        total_rounds: int,
+        executor: Callable[[object], TaskOutcome],
+    ) -> str:
+        del task_type, total_rounds
+        self.outcome = executor(object())
+        return 'task_decisive'
 
 
 def test_task_start_rejects_concurrent_task(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -99,3 +130,62 @@ def test_task_start_dispatches_request_with_shared_context(
     assert result is response
     assert calls == [(ctx, task_request)]
     assert ctx.stop_event is manager.stop_event
+
+
+def test_decisive_error_result_marks_task_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A decisive ERROR is a task failure, not a successful completed round."""
+    from autowsgr import ops
+    from autowsgr.ops import DecisiveResult
+
+    class ErrorController:
+        def __init__(self, _ctx: object, _config: object) -> None:
+            pass
+
+        def run(self) -> DecisiveResult:
+            return DecisiveResult.ERROR
+
+    manager = _ExecutingTaskManager()
+    monkeypatch.setattr(task, 'task_manager', manager)
+    monkeypatch.setattr(ops, 'DecisiveController', ErrorController)
+
+    asyncio.run(task._start_decisive(object(), DecisiveRequest()))
+
+    assert manager.outcome is not None
+    assert manager.outcome.success is False
+    assert manager.outcome.error == '决战异常退出'
+    assert manager.outcome.results == [
+        {
+            'round': 1,
+            'success': False,
+            'result': 'error',
+            'error': '决战异常退出',
+        }
+    ]
+
+
+def test_decisive_leave_result_remains_successful(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An intentional decisive leave remains a successful terminal result."""
+    from autowsgr import ops
+    from autowsgr.ops import DecisiveResult
+
+    class LeaveController:
+        def __init__(self, _ctx: object, _config: object) -> None:
+            pass
+
+        def run(self) -> DecisiveResult:
+            return DecisiveResult.LEAVE
+
+    manager = _ExecutingTaskManager()
+    monkeypatch.setattr(task, 'task_manager', manager)
+    monkeypatch.setattr(ops, 'DecisiveController', LeaveController)
+
+    asyncio.run(task._start_decisive(object(), DecisiveRequest()))
+
+    assert manager.outcome is not None
+    assert manager.outcome.success is True
+    assert manager.outcome.error is None
+    assert manager.outcome.results == [{'round': 1, 'success': True, 'result': 'leave'}]


### PR DESCRIPTION
## Summary
- allow TaskOutcome.from_results to preserve an explicit task-level error
- keep existing failed-round error inference when no explicit error is supplied
- classify DecisiveResult.ERROR as a failed result instead of successful completion
- preserve DecisiveResult.LEAVE as an intentional successful terminal result

## Error precedence
1. explicit task-level error
2. first specific failed-round error
3. generic failed-round error
4. empty-result failure

## TDD
The initial tests failed because TaskOutcome.from_results rejected the explicit error argument and decisive ERROR produced a successful outcome.

## Verification
- focused task manager and route tests: 25 passed
- complete suite with coverage: 591 passed
- Ruff check: passed
- Ruff format: passed
- codespell: passed
- diff-cover against origin/main: 100% patch coverage (10 changed executable lines, 0 missing)

## Scope
This PR is limited to TaskOutcome error precedence and decisive ERROR classification. It does not alter scheduler aggregation, stopped-result projection, device leasing, response schemas, native integration, or GUI files.