### PR TITLE
fix(server): type task status responses

### DIFF
--- a/autowsgr/server/routes/task.py
+++ b/autowsgr/server/routes/task.py
@@ -16,6 +16,7 @@ from autowsgr.server.schemas import (
     EventFightRequest,
     ExerciseRequest,
     NormalFightRequest,
+    TaskStatusResponse,
 )
 from autowsgr.server.serializers import build_combat_plan, convert_combat_result
 from autowsgr.server.task_manager import TaskOutcome, task_manager
@@ -85,11 +86,15 @@ async def task_stop() -> ApiResponse:
         return ApiResponse(success=False, error='停止失败')
 
 
-@router.get('/status', response_model=ApiResponse)
-async def task_status() -> ApiResponse:
+@router.get(
+    '/status',
+    response_model=ApiResponse[TaskStatusResponse],
+    response_model_exclude_unset=True,
+)
+async def task_status() -> ApiResponse[TaskStatusResponse]:
     """查询当前任务状态。"""
     status = task_manager.get_status()
-    return ApiResponse(success=True, data=status)
+    return ApiResponse[TaskStatusResponse](success=True, data=status)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/autowsgr/server/schemas.py
+++ b/autowsgr/server/schemas.py
@@ -285,6 +285,7 @@ class RoundResult(BaseModel):
     """单轮战斗结果。"""
 
     round: int = Field(description='轮次')
+    success: bool = Field(description='本轮是否成功')
     nodes: list[str] = Field(default_factory=list, description='经过的节点')
     mvp: str | None = Field(default=None, description='MVP 舰船')
     ship_damage: list[int] = Field(
@@ -292,6 +293,13 @@ class RoundResult(BaseModel):
         description='舰船破损状态',
     )
     grade: str | None = Field(default=None, description='战果等级')
+    node_count: int | None = Field(default=None, description='经过的节点数量')
+    enemies: dict[str, dict[str, int]] | None = Field(default=None, description='各节点敌舰')
+    events: list[dict[str, Any]] | None = Field(default=None, description='战斗事件')
+    result: str | None = Field(default=None, description='任务专用结果')
+    error: str | None = Field(default=None, description='本轮错误信息')
+
+    model_config = {'extra': 'allow'}
 
 
 class TaskResult(BaseModel):
@@ -330,11 +338,11 @@ class LogMessage(BaseModel):
     message: str = Field(description='日志内容')
 
 
-class ApiResponse(BaseModel):
+class ApiResponse[ResponseDataT](BaseModel):
     """通用 API 响应。"""
 
     success: bool = Field(description='是否成功')
-    data: Any | None = Field(default=None, description='响应数据')
+    data: ResponseDataT | None = Field(default=None, description='响应数据')
     message: str | None = Field(default=None, description='消息')
     error: str | None = Field(default=None, description='错误信息')
 

--- a/testing/server/test_task_routes.py
+++ b/testing/server/test_task_routes.py
@@ -13,11 +13,14 @@ from autowsgr.server import main as server_main
 from autowsgr.server.device_lease import DeviceOperationBusyError
 from autowsgr.server.routes import task
 from autowsgr.server.schemas import (
+    ApiResponse,
     CampaignRequest,
     DecisiveRequest,
     EventFightRequest,
     ExerciseRequest,
     NormalFightRequest,
+    RoundResult,
+    TaskStatusResponse,
 )
 
 
@@ -189,3 +192,85 @@ def test_decisive_leave_result_remains_successful(
     assert manager.outcome.success is True
     assert manager.outcome.error is None
     assert manager.outcome.results == [{'round': 1, 'success': True, 'result': 'leave'}]
+
+
+@pytest.mark.parametrize(
+    'detail',
+    [
+        {
+            'round': 1,
+            'success': True,
+            'nodes': ['A', 'B'],
+            'mvp': '位置1',
+            'grade': 'S',
+            'ship_damage': [0, 1],
+            'node_count': 2,
+            'enemies': {'B': {'DD': 2}},
+            'events': [{'type': 'FIGHT', 'node': 'B', 'custom': 'kept'}],
+        },
+        {'round': 2, 'success': False, 'error': 'fleet change failed'},
+        {'round': 3, 'success': True, 'result': 'leave'},
+    ],
+)
+def test_round_result_schema_preserves_existing_detail_shapes(
+    detail: dict[str, Any],
+) -> None:
+    """Typed task results must not strip or synthesize detail fields."""
+    assert RoundResult.model_validate(detail).model_dump(exclude_unset=True) == detail
+
+
+def test_task_status_openapi_exposes_typed_data() -> None:
+    """The status endpoint documents TaskStatusResponse instead of untyped Any."""
+    schema = server_main.app.openapi()
+    response_schema = schema['paths']['/api/task/status']['get']['responses']['200']['content'][
+        'application/json'
+    ]['schema']
+    response_model_name = response_schema['$ref'].rsplit('/', 1)[-1]
+    data_schema = schema['components']['schemas'][response_model_name]['properties']['data']
+
+    assert 'TaskStatusResponse' in str(data_schema)
+
+
+def test_typed_task_status_preserves_terminal_wire_payload() -> None:
+    """Typed envelope round-trips terminal details without adding absent fields."""
+    payload = {
+        'success': True,
+        'data': {
+            'task_id': 'task_1234',
+            'status': 'failed',
+            'progress': None,
+            'result': {
+                'total_runs': 2,
+                'success_runs': 1,
+                'details': [
+                    {'round': 1, 'success': True, 'result': 'leave'},
+                    {'round': 2, 'success': False, 'error': 'fleet change failed'},
+                ],
+            },
+            'error': 'fleet change failed',
+        },
+    }
+
+    response = ApiResponse[TaskStatusResponse].model_validate(payload)
+
+    assert response.model_dump(mode='json', exclude_unset=True) == payload
+
+
+def test_task_status_returns_typed_envelope(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The route validates manager status through its typed response contract."""
+    status = {
+        'task_id': None,
+        'status': 'idle',
+        'progress': None,
+        'result': None,
+    }
+    monkeypatch.setattr(task.task_manager, 'get_status', lambda: status)
+
+    response = asyncio.run(task.task_status())
+
+    assert isinstance(response, ApiResponse)
+    assert isinstance(response.data, TaskStatusResponse)
+    assert response.model_dump(mode='json', exclude_unset=True) == {
+        'success': True,
+        'data': status,
+    }


### PR DESCRIPTION
## Summary
- make ApiResponse generic so endpoints can document their concrete data contract
- publish TaskStatusResponse as the data schema for GET /api/task/status
- preserve all existing combat, failure, and decisive round-detail fields during validation and serialization
- keep forward-compatible unknown round fields instead of filtering executor extensions
- exclude unset response fields so non-combat details do not gain synthetic combat defaults

## Compatibility
The HTTP envelope and runtime JSON field names remain unchanged. The GUI currently has no runtime caller for taskStatus, while websocket consumers depend on result.details success and nodes; both fields are explicitly preserved.

## TDD
The initial tests showed the old RoundResult stripped success, node_count, enemies, events, error, and decisive result fields. OpenAPI also represented status data as untyped Any.

## Verification
- focused server task tests: 30 passed before final route coverage addition
- complete final suite with coverage: 597 passed
- Ruff check: passed
- Ruff format: passed
- codespell: passed
- diff-cover against origin/main: 100% patch coverage (12 changed executable lines, 0 missing)

## Scope
This PR only types the task-status response and its round-detail schema. It does not alter task execution, scheduler behavior, cancellation, decisive outcomes, device leasing, native integration, websockets, or GUI files.