### PR TITLE
fix(logging): 默认日志目录统一为 logs

### DIFF
--- a/autowsgr/infra/config.py
+++ b/autowsgr/infra/config.py
@@ -135,7 +135,7 @@ class LogConfig(BaseModel):
 
     level: Literal['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'] = 'DEBUG'
     """日志级别"""
-    root: Path = Path('log')
+    root: Path = Path('logs')
     """日志保存根目录"""
     dir: Path | None = None
     """日志保存路径。自动按日期生成"""

--- a/autowsgr/infra/logger.py
+++ b/autowsgr/infra/logger.py
@@ -30,7 +30,7 @@
     # 应用启动时调用一次
     from autowsgr.infra.logger import setup_logger
     setup_logger(
-        log_dir=Path("log/2026-01-01"),
+        log_dir=Path("logs/2026-01-01"),
         channels={
             "vision.pixel": "TRACE",   # 开启像素匹配逐条输出
             "emulator": "INFO",        # 屏蔽 click/swipe 的 DEBUG

--- a/docs/architecture/infra.md
+++ b/docs/architecture/infra.md
@@ -49,7 +49,7 @@ _log.info('进入战斗: {}', map_name)
 ### 日志输出
 
 - 控制台: 彩色输出
-- 文件: 每次启动独立目录 `log/{timestamp}/`
+- 文件: 每次启动独立目录 `logs/{timestamp}/`
 - 截图保存: `save_images=True` 时，配合 `save_screenshot()` 将调试截图保存到日志目录
 
 ---

--- a/usersettings.yaml
+++ b/usersettings.yaml
@@ -49,7 +49,7 @@ ocr:
 # ═══════════════════════════════════════════
 log:
   level: DEBUG                     # DEBUG / INFO / WARNING / ERROR / CRITICAL
-  root: log                        # 日志保存根目录
+  root: logs                       # 日志保存根目录
   # dir: null                      # 日志保存路径; null = 自动按日期生成
 
   # 细粒度显示开关


### PR DESCRIPTION
## 背景

后端默认日志根目录仍使用单数 `log`，与当前 GUI 和项目约定的 `logs` 不一致。本 PR 只统一默认目录，不包含 OCR、智能换船或架构拆分改动。

## 改动

- 将 `LogConfig.root` 默认值从 `log` 改为 `logs`
- 同步 `usersettings.yaml` 默认配置
- 同步 logger 示例和基础设施文档
- 用户显式配置的 `log.root` 不受影响

## 验证

- `uv run pytest -q testing/infra/test_config.py`：54 passed
- `uv run pre-commit run --from-ref upstream/main --to-ref HEAD`：全部通过
- `git diff --check upstream/main...HEAD`：通过