### PR TITLE
refactor(logging): 智能换船改造三期：统一关键节点与 OCR 诊断日志

### DIFF
--- a/autowsgr/ui/battle/detection.py
+++ b/autowsgr/ui/battle/detection.py
@@ -190,26 +190,19 @@ class DetectionMixin(BaseBattlePreparation):
                 prepared = cv2.cvtColor(binary, cv2.COLOR_GRAY2RGB)
 
             # 两种引擎统一使用等级字符集和同一套结果解析规则。
-            level = self._best_level_from_results(
-                ocr.recognize_line(
-                    prepared,
-                    easyocr_profile=EasyOCRProfile.FLEET_SHIP_LEVEL,
-                ),
+            ocr_results = ocr.recognize_line(
+                prepared,
+                easyocr_profile=EasyOCRProfile.FLEET_SHIP_LEVEL,
             )
+            level = self._best_level_from_results(ocr_results)
             levels[slot] = level
 
-            if level is not None:
-                _log.debug('[UI] 槽位{} 等级: Lv.{}', slot, level)
-            else:
-                _log.debug('[UI] 槽位{} 等级识别失败', slot)
-
-        _log.info(
-            '[准备页] 等级检测: {}',
-            ' | '.join(
-                f'槽{i}={"Lv." + str(levels[i]) if levels[i] is not None else "无"}'
-                for i in requested_slots
-            ),
-        )
+            _log.debug(
+                '[准备页] 等级OCR原始及后处理: 物理槽位={} raw={} parsed={}',
+                slot + 1,
+                ocr_results,
+                level,
+            )
         return levels
 
     # ── 舰种 OCR ─────────────────────────────────────────────────────────
@@ -250,21 +243,16 @@ class DetectionMixin(BaseBattlePreparation):
                 cropped,
                 (cropped.shape[1] * 4, cropped.shape[0] * 4),
             )
-            ship_type = self._best_ship_type_from_results(ocr.recognize(upscaled))
+            ocr_results = ocr.recognize(upscaled)
+            ship_type = self._best_ship_type_from_results(ocr_results)
             ship_types[slot] = ship_type
 
-            if ship_type is not None:
-                _log.debug('[UI] 槽位{} 舰种: {}', slot, ship_type.value)
-            else:
-                _log.debug('[UI] 槽位{} 舰种识别失败', slot)
-
-        _log.info(
-            '[准备页] 舰种检测: {}',
-            ' | '.join(
-                f'槽{i}={ship_types[i].value if ship_types[i] is not None else "未知"}'
-                for i in requested_slots
-            ),
-        )
+            _log.debug(
+                '[准备页] 舰种OCR原始及后处理: 物理槽位={} raw={} parsed={}',
+                slot + 1,
+                ocr_results,
+                ship_type.value if ship_type is not None else None,
+            )
         return ship_types
 
     @staticmethod

--- a/autowsgr/ui/battle/fleet_change/_alignment.py
+++ b/autowsgr/ui/battle/fleet_change/_alignment.py
@@ -82,11 +82,12 @@ class FleetAlignmentMixin(FleetSelectionMixin):
             ):
                 continue
 
-            _log.info(
+            _log.debug(
                 "[准备页] 槽位 {} 身份未知，先用备选 '{}' 释放原舰船",
-                target_slot,
+                target_slot + 1,
                 candidate.name,
             )
+            previous_name = current[target_slot]
             selection = self._try_select_option(target_slot, candidate)
             if selection.name is None:
                 unavailable.add((target_slot, candidate))
@@ -98,6 +99,12 @@ class FleetAlignmentMixin(FleetSelectionMixin):
 
             current[target_slot] = selection.name
             occupied[target_slot] = True
+            _log.info(
+                "[准备页] 换船: 槽位{} '{}' -> '{}'",
+                target_slot + 1,
+                previous_name or '未知舰船',
+                selection.name,
+            )
             time.sleep(0.3)
             return candidate
         return None
@@ -111,6 +118,7 @@ class FleetAlignmentMixin(FleetSelectionMixin):
         locked: dict[int, ShipSelector],
     ) -> bool:
         """尝试主选并同步已确认的槽位状态。"""
+        previous_name = current[target_slot]
         selection = self._try_select_option(target_slot, primary)
         if selection.name is None:
             return False
@@ -120,6 +128,12 @@ class FleetAlignmentMixin(FleetSelectionMixin):
             )
 
         current[target_slot] = selection.name
+        _log.info(
+            "[准备页] 换船: 槽位{} '{}' -> '{}'",
+            target_slot + 1,
+            previous_name or '未知舰船',
+            selection.name,
+        )
         locked[target_slot] = primary
         verified_slots.discard(target_slot)
         if self._requires_selection_validation(primary):
@@ -163,20 +177,20 @@ class FleetAlignmentMixin(FleetSelectionMixin):
                     unavailable,
                 )
                 if fallback is None:
-                    _log.warning(
+                    _log.debug(
                         '[准备页] 槽位 {} 没有可用备选，保留原换船流程',
-                        target_slot,
+                        target_slot + 1,
                     )
                     continue
-                _log.info(
+                _log.debug(
                     "[准备页] 槽位 {} 已释放，重新尝试主选 '{}'",
-                    target_slot,
+                    target_slot + 1,
                     primary.name,
                 )
             else:
-                _log.info(
+                _log.debug(
                     "[准备页] 槽位 {} 身份未知且没有备选，最后搜索一次主选 '{}'",
-                    target_slot,
+                    target_slot + 1,
                     primary.name,
                 )
 
@@ -221,6 +235,11 @@ class FleetAlignmentMixin(FleetSelectionMixin):
                     assigned,
                     verified_slots,
                 )
+            _log.info(
+                '[准备页] YAML目标编队调整: {} -> {}',
+                self._target_names(previous),
+                self._target_names(replanned),
+            )
 
     def _align_member_set(
         self,
@@ -273,9 +292,9 @@ class FleetAlignmentMixin(FleetSelectionMixin):
                 target_slot,
             )
             if ship_slot is None:
-                _log.warning(
+                _log.debug(
                     "[准备页] 目标槽位 {} 的规则 '{}' 不可用，重新规划备选",
-                    target_slot,
+                    target_slot + 1,
                     option.name,
                 )
                 unavailable.add((target_slot, option))
@@ -306,15 +325,21 @@ class FleetAlignmentMixin(FleetSelectionMixin):
                         assigned,
                         verified_slots,
                     )
+                _log.info(
+                    '[准备页] YAML目标编队调整: {} -> {}',
+                    self._target_names(previous),
+                    self._target_names(replanned),
+                )
                 continue
 
-            _log.info(
+            _log.debug(
                 "[准备页] 更换物理槽位 {} <- '{}' (逻辑槽位 {}, 原: '{}')",
-                ship_slot,
+                ship_slot + 1,
                 option.name,
-                target_slot,
+                target_slot + 1,
                 current[ship_slot],
             )
+            previous_name = current[ship_slot]
             selection = self._try_select_option(
                 ship_slot,
                 option,
@@ -329,6 +354,12 @@ class FleetAlignmentMixin(FleetSelectionMixin):
 
             current[ship_slot] = selection.name
             occupied[ship_slot] = True
+            _log.info(
+                "[准备页] 换船: 槽位{} '{}' -> '{}'",
+                ship_slot + 1,
+                previous_name or '空槽',
+                selection.name,
+            )
             locked[target_slot] = option
             verified_slots.discard(target_slot)
             if self._requires_selection_validation(option):
@@ -354,8 +385,13 @@ class FleetAlignmentMixin(FleetSelectionMixin):
         for slot in range(5, -1, -1):
             if slot in protected or not occupied[slot]:
                 continue
-            _log.info("[准备页] 移除多余槽位 {} 的 '{}'", slot, current[slot])
+            previous_name = current[slot]
             self._change_single_ship(slot, None, slot_occupied=True)
+            _log.info(
+                "[准备页] 换船: 槽位{} '{}' -> 空槽",
+                slot + 1,
+                previous_name or '未知舰船',
+            )
             # 游戏会将右侧舰船整体左移，直接同步已确认的成员位置。
             current.pop(slot)
             current.append(None)
@@ -438,13 +474,19 @@ class FleetAlignmentMixin(FleetSelectionMixin):
                     target,
                 )
                 continue
-            _log.info(
+            _log.debug(
                 "[准备页] 位置对齐: 槽位 {} <- '{}' (从槽位 {})",
-                i,
+                i + 1,
                 target,
-                src,
+                src + 1,
             )
             self._circular_move(src, i, current)
+            _log.info(
+                "[准备页] 调整位置: '{}' 槽位{} -> 槽位{}",
+                target,
+                src + 1,
+                i + 1,
+            )
 
     # 将一艘舰船从源槽位拖到目标槽位，并模拟游戏中的循环位移。
     def _circular_move(

--- a/autowsgr/ui/battle/fleet_change/_change.py
+++ b/autowsgr/ui/battle/fleet_change/_change.py
@@ -86,6 +86,180 @@ class FleetChangeMixin(FleetAlignmentMixin):
                 names.append(confirmed_name)
         return names, list(snapshot.occupied)
 
+    @classmethod
+    def _snapshot_option_match_result(
+        cls,
+        snapshot: FleetSnapshot,
+        slot: int,
+        option: ShipSelector,
+    ) -> str:
+        """说明已匹配舰名的舰种、等级是否满足一条规则。"""
+        if option.relaxed_constraints:
+            result = '通过: relaxed仅校验舰名'
+        else:
+            ship_type = snapshot.ship_types[slot] if snapshot.ship_types else None
+            ship_level = snapshot.ship_levels[slot] if snapshot.ship_levels else None
+            if option.ship_types and ship_type is None:
+                result = '不通过: 舰种未识别'
+            elif option.ship_types and ship_type not in option.ship_types:
+                result = f'不通过: 舰种{ship_type.value}不满足规则'
+            elif (
+                option.min_level is not None or option.max_level is not None
+            ) and ship_level is None:
+                result = '不通过: 等级未识别'
+            elif option.min_level is not None and ship_level < option.min_level:
+                result = f'不通过: 等级{ship_level}低于{option.min_level}'
+            elif option.max_level is not None and ship_level > option.max_level:
+                result = f'不通过: 等级{ship_level}高于{option.max_level}'
+            else:
+                result = '通过'
+        return result
+
+    @classmethod
+    def _snapshot_slot_match_result(
+        cls,
+        snapshot: FleetSnapshot,
+        slot: int,
+        selector: FleetSlotRule | None,
+    ) -> str:
+        """说明一个 OCR 槽位与同位置 YAML 规则的匹配结果。"""
+        name = snapshot.names[slot]
+        occupied = snapshot.occupied[slot]
+        if selector is None:
+            result = '通过' if not occupied and name is None else '不通过: YAML要求空槽'
+        elif not occupied:
+            result = '不通过: 槽位为空'
+        elif name is None:
+            result = '不通过: 舰名未识别'
+        else:
+            option = next(
+                (
+                    candidate
+                    for candidate in selector.options
+                    if cls._option_matches_name(name, candidate)
+                ),
+                None,
+            )
+            result = (
+                '不通过: 舰名不匹配'
+                if option is None
+                else cls._snapshot_option_match_result(snapshot, slot, option)
+            )
+        return result
+
+    @classmethod
+    def _log_snapshot_debug(
+        cls,
+        stage: str,
+        snapshot: FleetSnapshot,
+        selectors: Sequence[FleetSlotRule | None],
+    ) -> None:
+        """记录一轮 OCR 合并后的六槽结果、规则与匹配结论。"""
+        ship_types = snapshot.ship_types or [None] * 6
+        ship_levels = snapshot.ship_levels or [None] * 6
+        for slot, selector in enumerate(selectors):
+            ship_type = ship_types[slot]
+            _log.debug(
+                '[准备页] {} OCR后处理: 物理槽位={} occupied={} name={} type={} '
+                'level={} rule={} match={}',
+                stage,
+                slot + 1,
+                snapshot.occupied[slot],
+                snapshot.names[slot],
+                ship_type.value if ship_type is not None else None,
+                ship_levels[slot],
+                selector,
+                cls._snapshot_slot_match_result(snapshot, slot, selector),
+            )
+
+    @classmethod
+    def _assignment_failure_reason(
+        cls,
+        current: Sequence[str | None],
+        occupied: Sequence[bool],
+        assigned: Sequence[ShipSelector | None],
+        verified_slots: set[int] | frozenset[int],
+    ) -> str:
+        """返回最终舰队未满足 YAML 的逐槽原因。"""
+        reasons: list[str] = []
+        identities = [
+            identity for name in current if (identity := ship_name_identity(name)) is not None
+        ]
+        if len(identities) != len(set(identities)):
+            reasons.append('舰队中存在同名舰船')
+
+        for slot, option in enumerate(assigned):
+            name = current[slot]
+            if option is None:
+                if occupied[slot] or name is not None:
+                    reasons.append(f'槽位{slot + 1}应为空，实际为{name or "未知舰船"}')
+                continue
+            if not occupied[slot]:
+                reasons.append(f"槽位{slot + 1}为空，目标为'{option.name}'")
+            elif name is None:
+                reasons.append(f"槽位{slot + 1}舰名未识别，目标为'{option.name}'")
+            elif not cls._option_matches_name(name, option):
+                reasons.append(
+                    f"槽位{slot + 1}当前为'{name}'，目标为'{option.name}'",
+                )
+            elif cls._requires_selection_validation(option) and slot not in verified_slots:
+                reasons.append(
+                    f"槽位{slot + 1}的'{name}'未通过 strict 舰种或等级校验",
+                )
+        return '；'.join(reasons) or '最终校验未通过'
+
+    @classmethod
+    def _log_final_result(
+        cls,
+        current: Sequence[str | None],
+        occupied: Sequence[bool],
+        assigned: Sequence[ShipSelector | None],
+        verified_slots: set[int] | frozenset[int],
+        *,
+        passed: bool,
+    ) -> None:
+        """统一输出最终编队和 YAML 校验结论。"""
+        _log.info('[准备页] 最终编队: {}', list(current))
+        if passed:
+            _log.info('[准备页] YAML校验: 通过')
+            return
+        _log.error(
+            '[准备页] YAML校验: 不通过，{}',
+            cls._assignment_failure_reason(
+                current,
+                occupied,
+                assigned,
+                verified_slots,
+            ),
+        )
+
+    def _detect_position_snapshot(
+        self,
+        current: Sequence[str | None],
+        names: Sequence[str | None],
+        *,
+        stage: str,
+        round_number: int,
+    ) -> tuple[list[str | None], list[bool]]:
+        """记录并执行一轮最终位置 OCR，合并已确认的舰名。"""
+        _log.debug(
+            '[准备页] {}OCR开始: 轮次={}/{}',
+            stage,
+            round_number,
+            _MAX_SET_RETRIES + 1,
+        )
+        snapshot = self.detect_fleet_snapshot(expected_names=names)
+        merged, occupied = self._merge_position_snapshot(current, snapshot)
+        _log.debug(
+            '[准备页] {}OCR后处理: 轮次={} current={} occupied={} target={}',
+            stage,
+            round_number,
+            merged,
+            occupied,
+            names,
+        )
+        return merged, occupied
+
     def _prepare_members_for_reorder(
         self,
         attempt: int,
@@ -105,7 +279,7 @@ class FleetChangeMixin(FleetAlignmentMixin):
             assigned,
             verified_slots,
         ):
-            _log.info('[准备页] 目标成员已齐全, 直接调整舰船顺序')
+            _log.debug('[准备页] 目标成员已齐全, 直接调整舰船顺序')
             return current, occupied
 
         # 第一轮执行完整对齐，重试轮只处理错误槽位。
@@ -121,7 +295,7 @@ class FleetChangeMixin(FleetAlignmentMixin):
                 deferred_primary_slots,
             )
         else:
-            _log.info('[准备页] 第 {} 次重试: 局部修正', attempt)
+            _log.debug('[准备页] 第 {} 次重试: 局部修正', attempt)
             self._local_fix(
                 current,
                 occupied,
@@ -155,7 +329,7 @@ class FleetChangeMixin(FleetAlignmentMixin):
         # Step 3：主选全部保留，candidate-only 通过全局回溯分配唯一备选。
         assigned = self._plan_target_options(selectors)
         if assigned is None:
-            _log.error('[准备页] 目标编成无法满足主选和同舰唯一约束')
+            _log.error('[准备页] YAML校验: 不通过，目标编队无法满足主选和同舰唯一约束')
             return False
         # 第一舰队最后一艘舰船不能移除，但第一舰队本身允许更换编成。
         if fleet_id == 1 and assigned[0] is None:
@@ -165,15 +339,19 @@ class FleetChangeMixin(FleetAlignmentMixin):
         snapshot = self._detect_initial_snapshot(expected_pool, selectors)
         current = snapshot.names
         occupied = snapshot.occupied
+        _log.info('[准备页] 当前编队: {}', current)
         assigned = self._plan_target_options(
             selectors,
             current,
         )
         if assigned is None:
-            _log.error('[准备页] 当前舰队无法分配为主选优先的不重名编成')
+            _log.info('[准备页] 最终编队: {}', current)
+            _log.error(
+                '[准备页] YAML校验: 不通过，当前舰队无法分配为主选优先的不重名编成',
+            )
             return False
         _log.info(
-            '[准备页] 根据主选优先规则确定目标编成: {}',
+            '[准备页] YAML目标编队: {}',
             self._target_names(assigned),
         )
 
@@ -182,6 +360,16 @@ class FleetChangeMixin(FleetAlignmentMixin):
         verified_slots: set[int] = set()
         self._initial_snapshot = snapshot
         self._mark_snapshot_verified_slots(snapshot, assigned, verified_slots)
+        initial_valid = self._validate_assignment(
+            current,
+            occupied,
+            assigned,
+            verified_slots,
+        )
+        _log.info(
+            '[准备页] OCR校验: {}',
+            '通过' if initial_valid else '不通过，进入换船流程',
+        )
         deferred_primary_slots = self._deferred_primary_slots(
             snapshot,
             selectors,
@@ -198,7 +386,13 @@ class FleetChangeMixin(FleetAlignmentMixin):
                 assigned,
                 verified_slots,
             ):
-                _log.info('[准备页] 舰队已满足目标, 跳过换船')
+                self._log_final_result(
+                    current,
+                    occupied,
+                    assigned,
+                    verified_slots,
+                    passed=True,
+                )
                 self._last_changed_fleet = list(current)
                 return True
 
@@ -216,16 +410,37 @@ class FleetChangeMixin(FleetAlignmentMixin):
                     deferred_primary_slots,
                 )
             except _UnresolvedPrimaryError as error:
-                _log.error('[准备页] {}', error)
+                _log.error('[准备页] 换船失败: {}', error)
+                self._log_final_result(
+                    current,
+                    occupied,
+                    assigned,
+                    verified_slots,
+                    passed=False,
+                )
                 return False
+            except RuntimeError as error:
+                _log.error('[准备页] 换船失败: {}', error)
+                self._log_final_result(
+                    current,
+                    occupied,
+                    assigned,
+                    verified_slots,
+                    passed=False,
+                )
+                raise
 
             # Step 6：通过拖拽调整舰船顺序。
             names = self._target_names(assigned)
             self._reorder(current, names)
 
             # Step 7：最终 OCR 验证位置；有船但漏识别舰名时保留已确认信息。
-            snapshot = self.detect_fleet_snapshot(expected_names=names)
-            current, occupied = self._merge_position_snapshot(current, snapshot)
+            current, occupied = self._detect_position_snapshot(
+                current,
+                names,
+                stage='最终位置',
+                round_number=attempt + 1,
+            )
             # 最终舰队符合目标时，返回成功。
             if self._validate_assignment(
                 current,
@@ -233,27 +448,40 @@ class FleetChangeMixin(FleetAlignmentMixin):
                 assigned,
                 verified_slots,
             ):
-                _log.info('[准备页] 编成更换完成: {}', current)
+                self._log_final_result(
+                    current,
+                    occupied,
+                    assigned,
+                    verified_slots,
+                    passed=True,
+                )
                 self._last_changed_fleet = list(current)
                 return True
 
             # 仍有重试次数时，等待页面稳定后进入下一轮局部修正。
             if attempt < _MAX_SET_RETRIES:
-                _log.warning(
-                    '[准备页] 第 {}/{} 次验证失败, 重试...',
+                _log.debug(
+                    '[准备页] YAML校验第 {}/{} 次未通过，重新截图并局部修正',
                     attempt + 1,
                     _MAX_SET_RETRIES + 1,
                 )
                 time.sleep(0.5)
-                snapshot = self.detect_fleet_snapshot(expected_names=names)
-                current, occupied = self._merge_position_snapshot(current, snapshot)
+                current, occupied = self._detect_position_snapshot(
+                    current,
+                    names,
+                    stage='局部修正前',
+                    round_number=attempt + 2,
+                )
 
             # 所有重试都失败时，记录当前舰队并退出。
             else:
-                _log.error(
-                    '[准备页] 舰队设置在 {} 次尝试后仍然失败, 当前: {}',
-                    _MAX_SET_RETRIES + 1,
+                _log.error('[准备页] 换船失败: 已达到 {} 次尝试上限', _MAX_SET_RETRIES + 1)
+                self._log_final_result(
                     current,
+                    occupied,
+                    assigned,
+                    verified_slots,
+                    passed=False,
                 )
 
         return False
@@ -320,7 +548,7 @@ class FleetChangeMixin(FleetAlignmentMixin):
                 and type_options
                 and not any(ship_type in option.ship_types for option in type_options)
             ):
-                _log.info(
+                _log.debug(
                     '[准备页] {} 槽位 {} 舰种 {} 不符合 strict YAML，下一阶段重识别',
                     level,
                     slot + 1,
@@ -344,7 +572,7 @@ class FleetChangeMixin(FleetAlignmentMixin):
                     for option in level_options
                 )
             ):
-                _log.info(
+                _log.debug(
                     '[准备页] {} 槽位 {} 等级 {} 不符合 strict YAML，下一阶段重识别',
                     level,
                     slot + 1,
@@ -374,12 +602,13 @@ class FleetChangeMixin(FleetAlignmentMixin):
         LEVEL3 再补充一次；LEVEL4 最后补舰名，并只补主选或纯备选规则实际
         需要的舰种、等级。
         """
+        _log.debug('[准备页] LEVEL1 开始: 全局识别舰名并检测槽位占用')
         snapshot = self.detect_fleet_snapshot(
             expected_pool=expected_pool,
         )
-        _log.info('[准备页] LEVEL1 完成: 舰名未知槽位={}', snapshot.unknown_slots)
+        self._log_snapshot_debug('LEVEL1', snapshot, selectors)
 
-        _log.info('[准备页] LEVEL2 使用新截图首次识别舰名、舰种和等级')
+        _log.debug('[准备页] LEVEL2 开始: 新截图补识别舰名、舰种和等级')
         snapshot = self.fill_missing_fleet_snapshot(
             snapshot,
             expected_pool=expected_pool,
@@ -389,10 +618,11 @@ class FleetChangeMixin(FleetAlignmentMixin):
             selectors,
             level='LEVEL2',
         )
+        self._log_snapshot_debug('LEVEL2', snapshot, selectors)
 
         if snapshot.has_unknown_details:
-            _log.info(
-                '[准备页] LEVEL3 执行一次补识别: 舰名槽位={}, 舰种槽位={}, 等级槽位={}',
+            _log.debug(
+                '[准备页] LEVEL3 开始: 舰名槽位={}, 舰种槽位={}, 等级槽位={}',
                 snapshot.unknown_slots,
                 snapshot.unknown_type_slots,
                 snapshot.unknown_level_slots,
@@ -406,9 +636,12 @@ class FleetChangeMixin(FleetAlignmentMixin):
                 selectors,
                 level='LEVEL3',
             )
+            self._log_snapshot_debug('LEVEL3', snapshot, selectors)
+        else:
+            _log.debug('[准备页] LEVEL3 跳过: LEVEL2 已取得全部字段')
 
-        _log.info(
-            '[准备页] LEVEL4 最后补识别: 舰名槽位={}',
+        _log.debug(
+            '[准备页] LEVEL4 开始: 最后补识别舰名槽位={}',
             snapshot.unknown_slots,
         )
         snapshot = self.fill_missing_fleet_snapshot(
@@ -416,4 +649,5 @@ class FleetChangeMixin(FleetAlignmentMixin):
             expected_pool=expected_pool,
             detail_requirements=self._level4_detail_requirements(selectors),
         )
+        self._log_snapshot_debug('LEVEL4', snapshot, selectors)
         return snapshot

--- a/autowsgr/ui/battle/fleet_change/_detect.py
+++ b/autowsgr/ui/battle/fleet_change/_detect.py
@@ -199,10 +199,12 @@ class FleetDetectMixin(BaseBattlePreparation):
                 matched = self._match_context_ship_name(text, normalized_pool)
             recognized_ocr.append(
                 {
-                    'slot': slot,
+                    'physical_slot': slot + 1,
                     'raw': raw_text,
                     'patched': text,
                     'matched': matched,
+                    'confidence': r.confidence,
+                    'bbox': r.bbox,
                 }
             )
             # 完整船池和目标上下文都无法识别时跳过该文字。
@@ -210,13 +212,13 @@ class FleetDetectMixin(BaseBattlePreparation):
                 _log.debug("[准备页] OCR '{}' -> 无匹配, 跳过", raw_text)
                 continue
             ships[slot] = matched
-            _log.debug("[准备页] 槽位 {} OCR -> '{}'", slot, matched)
+            _log.debug("[准备页] 物理槽位 {} 舰名 OCR -> '{}'", slot + 1, matched)
 
-        _log.info(
-            '[准备页] 编队 OCR 识别: {}',
+        _log.debug(
+            '[准备页] 舰名OCR原始及后处理: {}',
             recognized_ocr,
         )
-        _log.info('[准备页] 当前舰队: {}', ships)
+        _log.debug('[准备页] 舰名OCR后处理编队: {}', ships)
         return ships
 
     def _recognize_fleet_names_at_slots(
@@ -255,7 +257,7 @@ class FleetDetectMixin(BaseBattlePreparation):
             crop = screen[y1:y2, max(0, int(left * w)) : min(w, int(right * w))]
             results = [result for result in ocr.recognize(crop) if result.text.strip()]
             if not results:
-                _log.debug('[准备页] 槽位 {} 舰名单槽 OCR 无文本', slot)
+                _log.debug('[准备页] 物理槽位 {} 舰名单槽OCR无文本', slot + 1)
                 continue
 
             result = max(results, key=lambda item: item.confidence)
@@ -270,10 +272,14 @@ class FleetDetectMixin(BaseBattlePreparation):
                 matched = self._match_context_ship_name(patched_text, normalized_pool)
             names[slot] = matched
             _log.debug(
-                "[准备页] 槽位 {} 舰名单槽 OCR: '{}' -> '{}'",
-                slot,
+                '[准备页] 舰名单槽OCR原始及后处理: 物理槽位={} raw={} patched={} '
+                'matched={} confidence={} bbox={}',
+                slot + 1,
                 raw_text,
+                patched_text,
                 matched,
+                result.confidence,
+                result.bbox,
             )
         return names
 

--- a/autowsgr/ui/battle/fleet_change/_planning.py
+++ b/autowsgr/ui/battle/fleet_change/_planning.py
@@ -232,14 +232,14 @@ class FleetPlanningMixin(FleetRuleMixin):
             if position is None:
                 continue
             if not self._snapshot_satisfies_option(snapshot, position, option):
-                _log.info(
+                _log.debug(
                     '[准备页] 快照校验未通过: 逻辑槽位 {} ({}), 进入选船二次确认',
                     target_slot,
                     snapshot.names[position],
                 )
                 continue
             verified_slots.add(target_slot)
-            _log.info(
+            _log.debug(
                 '[准备页] 快照确认逻辑槽位 {} 已就位 ({}), 跳过选船二次确认',
                 target_slot,
                 snapshot.names[position],

--- a/autowsgr/ui/choose_ship_page.py
+++ b/autowsgr/ui/choose_ship_page.py
@@ -187,7 +187,7 @@ class ChooseShipPage:
     # ── 操作 ──────────────────────────────────────────────────────────────
     def ensure_search_box(self) -> None:
         """点击搜索框，准备输入舰船名。"""
-        _log.info('[UI] 选船 → 打开搜索框')
+        _log.debug('[UI] 选船 → 打开搜索框')
         self._ctrl.click(*CLICK_SEARCH_BOX)
         wait_for_page(
             self._ctrl,
@@ -337,12 +337,12 @@ class ChooseShipPage:
                 row_key,
             )
             if detected_ship_type is None:
-                _log.warning("[UI] 命中 '{}', 但舰种未识别", matched)
+                _log.debug("[UI] 命中 '{}', 但舰种未识别", matched)
                 if not relaxed_constraints:
                     return _CardConstraintResult(accepted=False)
                 type_unknown = True
             elif not self._is_ship_type_in_rule(detected_ship_type, ship_type):
-                _log.warning(
+                _log.debug(
                     "[UI] 命中 '{}' 舰种 '{}' 不满足要求 '{}'",
                     matched,
                     detected_ship_type,
@@ -363,11 +363,11 @@ class ChooseShipPage:
             except LevelOCRRetryNeededError:
                 retry_level_ocr = True
                 level = None
-                _log.warning("[UI] 命中 '{}', 但等级 OCR 噪声过高", matched)
+                _log.debug("[UI] 命中 '{}', 但等级 OCR 噪声过高", matched)
 
             if level is None:
                 if not retry_level_ocr:
-                    _log.warning("[UI] 命中 '{}', 但等级未识别", matched)
+                    _log.debug("[UI] 命中 '{}', 但等级未识别", matched)
                 if not relaxed_constraints:
                     return _CardConstraintResult(
                         accepted=False,
@@ -375,7 +375,7 @@ class ChooseShipPage:
                     )
                 level_unknown = True
             elif not self._is_level_in_range(level, min_level, max_level):
-                _log.warning(
+                _log.debug(
                     "[UI] 命中 '{}', 但等级 {} 不满足范围 [{}, {}]",
                     matched,
                     level,
@@ -384,12 +384,21 @@ class ChooseShipPage:
                 )
                 return _CardConstraintResult(accepted=False)
 
-        return _CardConstraintResult(
+        result = _CardConstraintResult(
             accepted=True,
             type_unknown=type_unknown,
             level_unknown=level_unknown,
             retry_level_ocr=retry_level_ocr,
         )
+        _log.debug(
+            "[选船列表] 船卡校验通过: name='{}' row={} type_unknown={} level_unknown={} relaxed={}",
+            matched,
+            row_key,
+            type_unknown,
+            level_unknown,
+            relaxed_constraints,
+        )
+        return result
 
     def _click_ship_in_list(
         self,
@@ -436,6 +445,18 @@ class ChooseShipPage:
                 raw_hits = locate_ship_rows(ocr, screen)
 
             hits = [self._normalize_hit_entry(hit) for hit in raw_hits]
+            _log.debug(
+                "[选船列表] OCR轮次 {}/{}: target='{}' hits={} required_types={} "
+                'level_range=[{}, {}] relaxed={}',
+                attempt + 1,
+                _OCR_MAX_ATTEMPTS,
+                name,
+                hits,
+                [item.value for item in ship_type] if ship_type is not None else [],
+                min_level,
+                max_level,
+                relaxed_constraints,
+            )
             selected_hit: tuple[str, float, float] | None = None
             relaxed_hits: list[tuple[int, bool, int, tuple[str, float, float]]] = []
             retry_level_ocr = False
@@ -480,7 +501,7 @@ class ChooseShipPage:
             if selected_hit is not None:
                 matched, cx, cy = selected_hit
                 # 当前不判断“远征中”“维修中”等不可选状态；如需支持，应在点击前增加卡片状态识别。
-                _log.info(
+                _log.debug(
                     "[UI] 选船 DLL+OCR -> '{}' (第 {}/{} 次), 点击 ({:.3f}, {:.3f})",
                     name,
                     attempt + 1,
@@ -493,18 +514,18 @@ class ChooseShipPage:
                 return matched
 
             if retry_level_ocr and not relaxed_constraints:
-                _log.warning(
+                _log.debug(
                     '[UI] 等级 OCR 噪声过高，触发重新识别 (第 {}/{} 次)',
                     attempt + 1,
                     _OCR_MAX_ATTEMPTS,
                 )
                 if attempt >= _OCR_MAX_ATTEMPTS - 1:
-                    _log.error('[UI] 等级 OCR 噪声过高，本规则校验失败')
+                    _log.debug('[UI] 等级 OCR 噪声过高，本规则校验失败')
                     return None
                 time.sleep(0.3)
                 continue
 
-            _log.warning(
+            _log.debug(
                 "[UI] 选船列表未匹配到 '{}' (第 {}/{} 次), 向上滚动",
                 name,
                 attempt + 1,
@@ -568,10 +589,18 @@ class ChooseShipPage:
                 ship_type = self._extract_ship_type_from_text(text)
                 if ship_type is not None:
                     detected_types.add(ship_type)
+            _log.debug(
+                '[选船列表] 舰种OCR原始及后处理: row={} card_x={} scale={} raw={} parsed={}',
+                row_key,
+                cx,
+                scale,
+                results,
+                sorted(ship_type.value for ship_type in detected_types),
+            )
             if len(detected_types) == 1:
                 return next(iter(detected_types))
             if len(detected_types) > 1:
-                _log.warning(
+                _log.debug(
                     '[UI] 单卡舰种 OCR 得到多个结果: {}',
                     sorted(ship_type.value for ship_type in detected_types),
                 )

--- a/autowsgr/ui/utils/ship_list.py
+++ b/autowsgr/ui/utils/ship_list.py
@@ -187,6 +187,13 @@ def locate_ship_rows(
             matched_results = _match_ship_results(upscaled_results)
             result_scale = 2.0
 
+        _log.debug(
+            '[选船列表] 舰名OCR原始及后处理: row={} raw={} upscaled={} matched={}',
+            (y_start_720, y_end_720),
+            results,
+            upscaled_results,
+            [name for _, name in matched_results],
+        )
         for r, name in matched_results:
             if deduplicate_by_name and name in seen:
                 continue
@@ -367,6 +374,22 @@ def _probe_level_near_name(
                 split_level_hits.append(split_level)
 
         parsed_levels.extend(split_level_hits)
+        raw_results = [
+            {
+                'text': result.text,
+                'confidence': result.confidence,
+                'bbox': result.bbox,
+            }
+            for result in results
+        ]
+        _log.debug(
+            '[选船列表] 等级OCR原始及后处理: scale={} name_x={} raw={} parsed={} noisy_hits={}',
+            scale,
+            name_x,
+            raw_results,
+            parsed_levels,
+            noisy_level_hits,
+        )
         if parsed_levels:
             return max(parsed_levels)
 

--- a/testing/ui/battle_preparation/test_unit.py
+++ b/testing/ui/battle_preparation/test_unit.py
@@ -1249,8 +1249,8 @@ class TestContextShipNameMatch:
 
         try:
             with patch(
-                'autowsgr.ui.battle.fleet_change._detect._log.info',
-            ) as log_info:
+                'autowsgr.ui.battle.fleet_change._detect._log.debug',
+            ) as log_debug:
                 detected = page.detect_fleet(
                     np.zeros((720, 1280, 3), dtype=np.uint8),
                     expected_names=['契卡洛夫'],
@@ -1259,19 +1259,21 @@ class TestContextShipNameMatch:
             set_user_ship_name_aliases({})
 
         assert detected == ['85工程', None, None, None, None, None]
-        log_info.assert_any_call(
-            '[准备页] 编队 OCR 识别: {}',
+        log_debug.assert_any_call(
+            '[准备页] 舰名OCR原始及后处理: {}',
             [
                 {
-                    'slot': 0,
+                    'physical_slot': 1,
                     'raw': '契卡洛夫',
                     'patched': '契卡洛夫',
                     'matched': '85工程',
+                    'confidence': 0.99,
+                    'bbox': (127, 2, 167, 24),
                 }
             ],
         )
-        log_info.assert_any_call(
-            '[准备页] 当前舰队: {}',
+        log_debug.assert_any_call(
+            '[准备页] 舰名OCR后处理编队: {}',
             ['85工程', None, None, None, None, None],
         )
 
@@ -1993,10 +1995,11 @@ class TestSmartFleetChange:
 
         select_option.assert_called_once_with(0, primary)
         detect.assert_not_called()
-        error = str(log_error.call_args.args[1])
-        assert "槽位 1 的主选 'A' 选择失败" in error
-        assert '主选 OCR 识别失败' in error
-        assert '账号不存在该舰船' in error
+        errors = [str(item.args[1]) for item in log_error.call_args_list]
+        selection_error = next(error for error in errors if "槽位 1 的主选 'A' 选择失败" in error)
+        assert '主选 OCR 识别失败' in selection_error
+        assert '账号不存在该舰船' in selection_error
+        assert "槽位1舰名未识别，目标为'A'" in errors
 
     def test_unknown_slot_uses_candidate_then_rechecks_primary(self):
         page = BattlePreparationPage(_make_ctx(MagicMock(spec=AndroidController)))


### PR DESCRIPTION
## 依赖与审查顺序

本 PR 是智能换船改造三期，采用堆叠式提交，依赖顺序为：

1. #536：FastOCR 舰船识别基础，已合入；
2. #537：智能换船可靠性一期；
3. #539：智能换船可靠性二期与模块拆分；
4. 本 PR：在 #539 头部 `bed3a5e` 上追加日志改造提交 `093bf60`。

在 #537、#539 合入前，GitHub 相对 `main` 的 Files changed 会暂时包含前两期依赖。三期自身的准确差异请查看：

- [二期到三期的完整差异](https://github.com/ShiinaKuroko/AutoWSGR/compare/refactor/fleet-change-modules...refactor/smart-fleet-change-phase-3-logging)
- 三期唯一提交：`093bf60 refactor(logging): 优化准备页换船与 OCR 日志`

## 一、改动背景

智能换船已经具备多阶段 OCR、主选优先、备选托底、成员对齐和最终验证能力，但原日志存在两个问题：

1. INFO 混入大量截图、点击和中间重试信息，用户难以判断“当前编队是什么、换了哪艘船、最终是否满足 YAML”；
2. OCR 失败时缺少完整原始结果、物理槽位和规则匹配上下文，DEBUG 无法还原每一轮识别与选船过程。

本期仅重构智能换船相关日志，不改变任何业务算法。

## 二、日志分层

### INFO：用户需要看到的业务结论

- 当前编队；
- YAML 目标编队；
- 初始 OCR 校验是否通过；
- 实际换船：槽位、原舰船、目标舰船；
- 舰船位置调整；
- 备选托底导致的 YAML 目标调整；
- 最终编队；
- 最终 YAML 校验是否通过。

### DEBUG：能够复现完整识别和换船流程

- LEVEL1～LEVEL4 每轮开始、跳过和后处理结果；
- 每个物理槽位的 `name`、`level`、`type`、占用状态、YAML 规则和匹配结论；
- 舰名 OCR 原文、纠错结果、标准舰名匹配、置信度和 bbox；
- 舰种、等级 OCR 原始返回及解析结果；
- 船池每轮命中结果、卡片坐标、规则约束、通过或拒绝原因；
- 主选、备选、托底、重新规划、局部修正和最终位置 OCR 路径。

### ERROR：明确最终失败原因

- YAML 目标无法分配；
- 主选、备选均不可用；
- 船池没有符合规则的舰船；
- 换船或排序达到重试上限；
- 最终舰名、舰种、等级或槽位不满足 YAML，并给出对应槽位原因。

## 三、严格改动范围

三期相对 #539 只修改以下 8 个文件：

- `autowsgr/ui/battle/detection.py`
- `autowsgr/ui/battle/fleet_change/_alignment.py`
- `autowsgr/ui/battle/fleet_change/_change.py`
- `autowsgr/ui/battle/fleet_change/_detect.py`
- `autowsgr/ui/battle/fleet_change/_planning.py`
- `autowsgr/ui/choose_ship_page.py`
- `autowsgr/ui/utils/ship_list.py`
- `testing/ui/battle_preparation/test_unit.py`

> [!IMPORTANT]
> 本 PR 没有改动编队、换船、OCR、选船范围以外的任何业务模块。
>
> 没有修改 YAML/API 结构、舰队规则语义、主选/备选优先级、strict/relaxed 校验、OCR 引擎参数、截图裁剪坐标、重试次数、船池点击逻辑、补给、修理、阵型、地图导航、战斗流程、配置加载或 GUI 接口。

所有业务入口和返回值保持不变；修改内容仅包括日志级别、日志文本、诊断上下文和对应日志断言。

## 四、设计结论

- INFO 只承担“发生了什么”和“最终是否成功”，不输出逐槽 OCR 细节；
- DEBUG 保留原始 OCR 和每轮决策链，使一次日志能够定位到模型识别、后处理、规则匹配、候选筛选或最终验证中的具体问题；
- 实际换船成功后才记录 INFO，尝试和失败候选只记录 DEBUG；
- 最终 YAML 失败统一按物理槽位输出原因，避免只看到笼统的“换船失败”；
- 复用现有 `FleetSnapshot`、`FleetSlotRule`、`ShipSelector` 和既有调用路径，没有引入新的业务状态。

## 五、测试结果

在以 #539 头部创建的独立 PR 分支执行：

- 定向测试：`185 passed`
  - `testing/ui/battle_preparation/test_unit.py`
  - `testing/ui/test_choose_ship_page.py`
  - `testing/ui/test_ship_list.py`
- 全量测试：`862 passed`
- pre-commit：全部 hooks 通过
- `git diff --check origin/refactor/fleet-change-modules...HEAD`：通过

## 六、风险与回退

- 运行风险集中在日志内容和 DEBUG 输出量，不涉及换船行为变化；
- INFO 数量显著收敛，DEBUG 开启时会输出更完整的逐轮 OCR 数据，这是预期行为；
- 三期只有一个独立提交，可直接回退 `093bf60`，不影响一期、二期业务实现。

## 七、审查重点

1. INFO 是否只保留当前编队、目标、实际变化和最终结论；
2. DEBUG 是否足够还原每轮 `name/level/type` OCR 与候选筛选；
3. 最终 YAML 失败原因是否准确落到物理槽位；
4. 三期相对 #539 是否严格限制在上述 8 个文件，且没有业务逻辑变化。